### PR TITLE
Fix tests by injecting test data path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,14 +56,13 @@ FetchContent_Declare(
 )
 
 # For macOS/Linux, to avoid re-downloading every time:
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-    FetchContent_Populate(googletest)
-    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
-endif()
+FetchContent_MakeAvailable(googletest)
 
 # Define your test executable
 add_executable(run_tests tests/test_DataReader.cpp)
+
+# Provide absolute path to the test data directory
+target_compile_definitions(run_tests PRIVATE "TEST_DATA_DIR=\"${CMAKE_SOURCE_DIR}/test_data\"")
 
 # Link your main library and Google Test to the test executable
 target_link_libraries(run_tests 

--- a/tests/test_DataReader.cpp
+++ b/tests/test_DataReader.cpp
@@ -4,13 +4,17 @@
 #include <vector>
 #include <chrono>
 
+// This macro is provided by CMake to locate the test data directory
+#ifndef TEST_DATA_DIR
+#define TEST_DATA_DIR "."
+#endif
+
 // Test fixture to ensure the test data file exists
 class DataReaderTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        // This assumes the test parquet file is in a `test_data` directory
-        // relative to where the tests are run (usually the build directory).
-        file_path = "../../test_data/test_bars.parquet"; 
+        // Construct an absolute path to the test parquet file
+        file_path = std::string(TEST_DATA_DIR) + "/test_bars.parquet";
     }
 
     std::string file_path;


### PR DESCRIPTION
## Summary
- revert previous removal of Arrow and GoogleTest
- define `TEST_DATA_DIR` for C++ tests in CMake
- modernize GoogleTest setup with `FetchContent_MakeAvailable`
- update test fixture to use the macro

## Testing
- `./build.sh` *(fails: Arrow and pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684cdd13f0a8832dabeddfe8e49715d2