### PR TITLE
feat(orderbook): queue-position-aware limit order fills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout (with Eigen submodule)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ add_executable(run_tests
     tests/cpp/QueuePositionTest.cpp
     tests/cpp/ImpactTest.cpp
     tests/cpp/DepthFillTest.cpp
+    tests/cpp/LimitQueueFillTest.cpp
 )
 
 target_link_libraries(run_tests PRIVATE qse gmock gtest_main)

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -45,7 +45,7 @@ bottom within a track; tracks are mostly independent of each other.
 - **Done when:** new gtest proves a large order pays more per share than a
   small one against the same book, and the config flag toggles between models.
 
-### A3. Queue-position-aware limit order fills
+### A3. ✅ Queue-position-aware limit order fills (done 2026-07-04)
 - Limit orders join the back of the queue at their level; they fill only after
   the queue ahead is consumed by trades at that price. Uses the existing
   `queue_position` machinery.

--- a/include/qse/data/OrderBookFullDepth.h
+++ b/include/qse/data/OrderBookFullDepth.h
@@ -94,7 +94,23 @@ public:
      * @return The queue ID assigned to this order
      */
     QueueId enqueue_order(Order::Side side, Price price, OrderId order_id, Volume size);
-    
+
+    /**
+     * @brief Adds an order to the FRONT of a price level's queue.
+     * Used to model displayed quote liquidity as being ahead of strategy
+     * orders resting at the same price (conservative queue assumption).
+     * @return The queue ID assigned, or 0 if the order ID already rests there
+     */
+    QueueId enqueue_order_front(Order::Side side, Price price, OrderId order_id, Volume size);
+
+    /**
+     * @brief Consumes up to `quantity` from the FIFO queue at one price level
+     * (e.g. a trade print at that price) and reports which resting orders
+     * were consumed and by how much. Removes the level if it empties.
+     * @return Pairs of (order_id, consumed_size) in FIFO order
+     */
+    std::vector<std::pair<OrderId, Volume>> consume_at_price(Order::Side side, Price price, Volume quantity);
+
     /**
      * @brief Removes and returns the order ID at the front of a price level's queue.
      * @param side The side (BUY/SELL)
@@ -179,7 +195,16 @@ private:
     
     // Mapping from QueueId to OrderId for position lookups
     std::unordered_map<QueueId, OrderId> queue_id_to_order_id_;
-    
+
+    // Synthetic displayed liquidity from the latest quote (one per side)
+    QueueId synthetic_bid_qid_ = 0;
+    QueueId synthetic_ask_qid_ = 0;
+    Price synthetic_bid_price_ = 0.0;
+    Price synthetic_ask_price_ = 0.0;
+
+    // Removes the synthetic quote order for a side, if it still rests
+    void remove_synthetic(Order::Side side);
+
     // Helper methods
     const std::map<Price, Level, std::greater<Price>>& get_bids() const { return bids_; }
     const std::map<Price, Level, std::less<Price>>& get_asks() const { return asks_; }

--- a/include/qse/order/OrderManager.h
+++ b/include/qse/order/OrderManager.h
@@ -76,6 +76,9 @@ namespace qse {
         // Full-depth fill model state
         bool use_full_depth_ = false;
         std::unordered_map<std::string, OrderBookFullDepth> depth_books_;
+
+        // QueueId of each strategy limit order resting in a depth book
+        std::unordered_map<OrderId, QueueId> limit_queue_ids_;
         
         // Portfolio state
         double cash_;
@@ -110,6 +113,19 @@ namespace qse {
         // New helper methods for OrderBook integration
         Volume process_limit_order_fill(Order& order, const TopOfBook& tob);
         Volume process_ioc_order_fill(Order& order, const TopOfBook& tob);
+
+        // --- Full-depth fill model helpers ---
+        // Walks the opposite side of the depth book while the taker's price
+        // allows (unbounded for market orders, capped at limit_price for
+        // limit orders), fills the taker at the VWAP of consumed liquidity,
+        // and credits any strategy maker orders that were consumed.
+        Volume take_liquidity(Order& taker, OrderBookFullDepth& book, const Tick& tick);
+        // A trade print consumes the FIFO queue at its price level; strategy
+        // orders reached by the print are filled at that price.
+        void consume_trade_print(const Tick& tick);
+        // Credits a maker fill to a strategy order consumed from the book
+        // (order ids not tracked in orders_ are synthetic/seeded liquidity).
+        void apply_maker_fill(const OrderId& maker_id, Volume qty, Price price, const Tick& tick);
         
         // Legacy helper methods
         void log_trade(long long timestamp, const std::string& symbol, const std::string& type, int quantity, double price);

--- a/src/data/OrderBookFullDepth.cpp
+++ b/src/data/OrderBookFullDepth.cpp
@@ -91,6 +91,77 @@ QueueId OrderBookFullDepth::enqueue_order(Order::Side side, Price price, OrderId
     return queue_id;
 }
 
+QueueId OrderBookFullDepth::enqueue_order_front(Order::Side side, Price price, OrderId order_id, Volume size) {
+    add_level(side, price);
+
+    Level& level = (side == Order::Side::BUY) ? get_bids()[price] : get_asks()[price];
+
+    // Reject duplicate OrderId at the same price level
+    if (level.position_map.find(order_id) != level.position_map.end()) {
+        return 0;
+    }
+
+    QueueId queue_id = allocate_queue_id();
+    queue_id_to_order_id_[queue_id] = order_id;
+
+    // Everyone already queued moves one position back
+    for (auto& pos_pair : level.position_map) {
+        pos_pair.second++;
+    }
+    level.queue.push_front(order_id);
+    level.total_size += size;
+    level.order_sizes[order_id] = size;
+    level.position_map[order_id] = 1;
+
+    return queue_id;
+}
+
+std::vector<std::pair<OrderId, Volume>> OrderBookFullDepth::consume_at_price(Order::Side side, Price price, Volume quantity) {
+    std::vector<std::pair<OrderId, Volume>> consumed;
+
+    auto process = [&](auto& levels) {
+        auto it = levels.find(price);
+        if (it == levels.end()) {
+            return;
+        }
+        Level& level = it->second;
+        Volume remaining = quantity;
+
+        while (!level.queue.empty() && remaining > 0) {
+            const OrderId& head_id = level.queue.front();
+            auto size_it = level.order_sizes.find(head_id);
+            Volume head_size = (size_it != level.order_sizes.end()) ? size_it->second : 0;
+
+            if (head_size <= remaining) {
+                // Fully consume the head order (skip zero-size stragglers)
+                if (head_size > 0) {
+                    consumed.emplace_back(head_id, head_size);
+                }
+                remaining -= head_size;
+                dequeue_head(side, price);
+            } else {
+                // Partially consume the head order; it keeps its queue position
+                consumed.emplace_back(head_id, remaining);
+                size_it->second -= remaining;
+                level.total_size -= remaining;
+                remaining = 0;
+            }
+        }
+
+        if (level.queue.empty()) {
+            levels.erase(it);
+        }
+    };
+
+    if (side == Order::Side::BUY) {
+        process(get_bids());
+    } else {
+        process(get_asks());
+    }
+
+    return consumed;
+}
+
 OrderId OrderBookFullDepth::dequeue_head(Order::Side side, Price price) {
     if (side == Order::Side::BUY) {
         auto& bids = get_bids();
@@ -254,17 +325,32 @@ TopOfBook OrderBookFullDepth::top_of_book() const {
 // --- Legacy Interface (for backward compatibility) ---
 
 void OrderBookFullDepth::on_tick(const Tick& tick) {
-    // Rebuild synthetic depth from the tick's quote. Until real L2 data is
-    // replayed, the tick's top-of-book is all the liquidity we know about,
-    // so the book holds one synthetic resting order per side.
-    bids_.clear();
-    asks_.clear();
-    queue_id_to_order_id_.clear();
+    // Refresh synthetic displayed liquidity from the tick's quote while
+    // preserving resting strategy orders and their FIFO positions. Displayed
+    // size is re-inserted at the FRONT of its level: with L1 data we cannot
+    // see the real queue, so displayed liquidity is conservatively assumed to
+    // be ahead of strategy orders resting at the same price. Queue progress
+    // within a quote interval comes from trade prints consuming the level.
+    remove_synthetic(Order::Side::BUY);
+    remove_synthetic(Order::Side::SELL);
     if (tick.bid_size > 0) {
-        enqueue_order(Order::Side::BUY, tick.bid, "__quote_bid", tick.bid_size);
+        synthetic_bid_qid_ = enqueue_order_front(Order::Side::BUY, tick.bid, "__quote_bid", tick.bid_size);
+        synthetic_bid_price_ = tick.bid;
     }
     if (tick.ask_size > 0) {
-        enqueue_order(Order::Side::SELL, tick.ask, "__quote_ask", tick.ask_size);
+        synthetic_ask_qid_ = enqueue_order_front(Order::Side::SELL, tick.ask, "__quote_ask", tick.ask_size);
+        synthetic_ask_price_ = tick.ask;
+    }
+}
+
+void OrderBookFullDepth::remove_synthetic(Order::Side side) {
+    QueueId& qid = (side == Order::Side::BUY) ? synthetic_bid_qid_ : synthetic_ask_qid_;
+    Price price = (side == Order::Side::BUY) ? synthetic_bid_price_ : synthetic_ask_price_;
+    if (qid != 0) {
+        // May already be gone if a trade print fully consumed it
+        cancel_order(qid);
+        remove_level_if_empty(side, price);
+        qid = 0;
     }
 }
 

--- a/src/order/OrderManager.cpp
+++ b/src/order/OrderManager.cpp
@@ -200,8 +200,32 @@ OrderId OrderManager::submit_limit_order(const std::string& symbol, Order::Side 
     if (tif == Order::TimeInForce::IOC) {
         order.expiry_time = order.timestamp;
     }
-    
+
     add_order_to_book(order);
+
+    if (use_full_depth_) {
+        // Any marketable portion takes liquidity immediately; the remainder
+        // rests in the depth book behind the existing queue at its price
+        Order& stored = orders_[order_id];
+        Tick submit_tick{};
+        submit_tick.symbol = symbol;
+        submit_tick.timestamp = stored.timestamp;
+
+        auto& book = depth_books_[symbol];
+        take_liquidity(stored, book, submit_tick);
+
+        if (stored.is_filled()) {
+            remove_order_from_book(order_id);
+        } else if (tif == Order::TimeInForce::IOC) {
+            // IOC never rests: cancel whatever could not fill immediately
+            stored.status = Order::Status::CANCELLED;
+            remove_order_from_book(order_id);
+        } else {
+            QueueId qid = book.enqueue_order(side, limit_price, order_id, stored.remaining_quantity());
+            limit_queue_ids_[order_id] = qid;
+        }
+    }
+
     return order_id;
 }
 
@@ -215,8 +239,20 @@ bool OrderManager::cancel_order(const OrderId& order_id) {
     if (order.status != Order::Status::PENDING && order.status != Order::Status::PARTIALLY_FILLED) {
         return false; // Order cannot be cancelled
     }
-    
+
     order.status = Order::Status::CANCELLED;
+
+    // If the order rests in a depth book, pull it out of the FIFO queue
+    auto qid_it = limit_queue_ids_.find(order_id);
+    if (qid_it != limit_queue_ids_.end()) {
+        auto db_it = depth_books_.find(order.symbol);
+        if (db_it != depth_books_.end()) {
+            db_it->second.cancel_order(qid_it->second);
+            db_it->second.remove_level_if_empty(order.side, order.limit_price);
+        }
+        limit_queue_ids_.erase(qid_it);
+    }
+
     remove_order_from_book(order_id);
     return true;
 }
@@ -224,6 +260,12 @@ bool OrderManager::cancel_order(const OrderId& order_id) {
 void OrderManager::process_tick(const Tick& tick) {
     // Update the order book first
     if (use_full_depth_) {
+        // The tick's trade consumes the FIFO queue at its price (advancing
+        // and possibly filling resting strategy orders) BEFORE the quote
+        // refresh re-inserts synthetic displayed liquidity
+        if (tick.volume > 0 && tick.price > 0) {
+            consume_trade_print(tick);
+        }
         depth_books_[tick.symbol].on_tick(tick);
     } else if (order_book_ != nullptr) {
         order_book_->on_tick(tick);
@@ -309,7 +351,9 @@ void OrderManager::match_orders_for_symbol(const std::string& symbol, const Tick
         return;
     }
     
-    std::vector<OrderId>& order_ids = symbol_it->second;
+    // Iterate a copy: maker fills triggered inside the loop can remove
+    // entries from symbol_orders_ and invalidate references into it
+    std::vector<OrderId> order_ids = symbol_it->second;
     std::cout << "DEBUG: Found " << order_ids.size() << " orders for symbol " << symbol << std::endl;
     std::vector<OrderId> to_remove;
     
@@ -342,19 +386,26 @@ void OrderManager::match_orders_for_symbol(const std::string& symbol, const Tick
         Price fill_price = 0.0;
         bool depth_fill = false;
 
-        if (order.type == Order::Type::MARKET) {
-            if (use_full_depth_) {
-                // Walk the full-depth book: fill price is the VWAP of the
-                // liquidity consumed, so large orders pay realistic impact
+        if (use_full_depth_) {
+            if (order.type == Order::Type::MARKET) {
+                // Walk the full-depth book: the taker pays the VWAP of the
+                // liquidity consumed, and any strategy maker orders that
+                // were consumed get credited with their fills
                 auto db_it = depth_books_.find(symbol);
                 if (db_it != depth_books_.end()) {
-                    auto result = db_it->second.fill_market(
-                        order.side, static_cast<std::int64_t>(order.remaining_quantity()));
-                    fill_qty = result.first;
-                    fill_price = result.second;
-                    depth_fill = true;
+                    take_liquidity(order, db_it->second, tick);
+                    if (order.is_filled()) {
+                        to_remove.push_back(order_id);
+                    }
                 }
-            } else if (order_book_ != nullptr) {
+            }
+            // LIMIT orders rest in the depth book; their fills come from
+            // trade prints consuming the queue (consume_trade_print)
+            continue;
+        }
+
+        if (order.type == Order::Type::MARKET) {
+            if (order_book_ != nullptr) {
                 // Use OrderBook to consume liquidity
                 fill_qty = order_book_->consume_liquidity(symbol, order.side, order.remaining_quantity());
                 if (fill_qty > 0) {
@@ -367,10 +418,8 @@ void OrderManager::match_orders_for_symbol(const std::string& symbol, const Tick
             }
             std::cout << "DEBUG: Market order fill_qty=" << fill_qty << " at " << fill_price << std::endl;
         } else if (order.type == Order::Type::LIMIT) {
-            // Use OrderBook for limit order fills (full-depth limit fills with
-            // queue position land in A3; until then full-depth mode uses the
-            // tick-based fallback below)
-            if (!use_full_depth_ && order_book_ != nullptr) {
+            // Use OrderBook for limit order fills
+            if (order_book_ != nullptr) {
                 fill_qty = process_limit_order_fill(order, tob);
                 if (fill_qty > 0) {
                     fill_price = (order.side == Order::Side::BUY) ? tob.best_ask_price : tob.best_bid_price;
@@ -563,7 +612,10 @@ void OrderManager::attempt_fills() {
 
         std::vector<OrderId> to_remove;
 
-        for (const OrderId& order_id : symbol_it->second) {
+        // Iterate a copy: maker fills triggered inside the loop can remove
+        // entries from symbol_orders_ and invalidate references into it
+        std::vector<OrderId> order_ids = symbol_it->second;
+        for (const OrderId& order_id : order_ids) {
             auto order_it = orders_.find(order_id);
             if (order_it == orders_.end()) {
                 continue;
@@ -574,34 +626,44 @@ void OrderManager::attempt_fills() {
                 continue;
             }
 
-            Volume fill_qty = 0;
-            Price fill_price = 0.0;
-            bool depth_fill = false;
+            if (depth != nullptr) {
+                if (order.type == Order::Type::MARKET) {
+                    // Walk the full-depth book: the taker pays the VWAP of
+                    // consumed liquidity, and any strategy maker orders that
+                    // were consumed get credited with their fills
+                    Tick book_tick{};
+                    book_tick.symbol = symbol;
+                    book_tick.timestamp = std::chrono::system_clock::now();
+                    book_tick.bid = tob.best_bid_price;
+                    book_tick.ask = tob.best_ask_price;
+                    book_tick.bid_size = tob.best_bid_size;
+                    book_tick.ask_size = tob.best_ask_size;
+                    book_tick.price = tob.mid_price();
 
-            if (order.type == Order::Type::MARKET) {
-                if (depth != nullptr) {
-                    // Walk the full-depth book: fill price is the VWAP of the
-                    // liquidity consumed, so large orders pay realistic impact
-                    auto result = depth->fill_market(
-                        order.side, static_cast<std::int64_t>(order.remaining_quantity()));
-                    fill_qty = result.first;
-                    fill_price = result.second;
-                    depth_fill = true;
-                } else {
-                    // Market orders fill immediately at the touch
-                    fill_qty = order_book_->consume_liquidity(symbol, order.side, order.remaining_quantity());
-                    if (fill_qty > 0) {
-                        fill_price = (order.side == Order::Side::BUY) ? tob.best_ask_price : tob.best_bid_price;
+                    take_liquidity(order, *depth, book_tick);
+                    if (order.is_filled()) {
+                        to_remove.push_back(order_id);
                     }
                 }
+                // LIMIT orders rest in the depth book; their fills come from
+                // trade prints consuming the queue (consume_trade_print)
+                continue;
+            }
+
+            Volume fill_qty = 0;
+            Price fill_price = 0.0;
+
+            if (order.type == Order::Type::MARKET) {
+                // Market orders fill immediately at the touch
+                fill_qty = order_book_->consume_liquidity(symbol, order.side, order.remaining_quantity());
+                if (fill_qty > 0) {
+                    fill_price = (order.side == Order::Side::BUY) ? tob.best_ask_price : tob.best_bid_price;
+                }
             } else if (order.type == Order::Type::LIMIT) {
-                // Limit orders fill when price crosses limit (full-depth limit
-                // fills with queue position land in A3)
-                if (!use_full_depth_) {
-                    fill_qty = process_limit_order_fill(order, tob);
-                    if (fill_qty > 0) {
-                        fill_price = (order.side == Order::Side::BUY) ? tob.best_ask_price : tob.best_bid_price;
-                    }
+                // Limit orders fill when price crosses limit
+                fill_qty = process_limit_order_fill(order, tob);
+                if (fill_qty > 0) {
+                    fill_price = (order.side == Order::Side::BUY) ? tob.best_ask_price : tob.best_bid_price;
                 }
             }
 
@@ -617,7 +679,7 @@ void OrderManager::attempt_fills() {
                 dummy_tick.price = (tob.best_bid_price + tob.best_ask_price) / 2.0;
                 dummy_tick.volume = fill_qty;
 
-                fill_order(order, fill_qty, fill_price, dummy_tick, depth_fill);
+                fill_order(order, fill_qty, fill_price, dummy_tick);
 
                 // Emit fill callback if registered
                 if (fill_callback_) {
@@ -642,6 +704,101 @@ void OrderManager::attempt_fills() {
 // --- NEW: Set fill callback for strategy notifications ---
 void OrderManager::set_fill_callback(FillCallback callback) {
     fill_callback_ = callback;
+}
+
+// --- Full-depth fill model helpers ---
+
+Volume OrderManager::take_liquidity(Order& taker, OrderBookFullDepth& book, const Tick& tick) {
+    Order::Side maker_side = (taker.side == Order::Side::BUY) ? Order::Side::SELL : Order::Side::BUY;
+    Volume want = taker.remaining_quantity();
+    Volume total = 0;
+    double value = 0.0;
+
+    while (total < want) {
+        TopOfBook tob = book.top_of_book();
+        Price level_price = 0.0;
+        bool crossable = false;
+        if (taker.side == Order::Side::BUY) {
+            crossable = tob.has_ask() &&
+                        (taker.type == Order::Type::MARKET || tob.best_ask_price <= taker.limit_price);
+            level_price = tob.best_ask_price;
+        } else {
+            crossable = tob.has_bid() &&
+                        (taker.type == Order::Type::MARKET || tob.best_bid_price >= taker.limit_price);
+            level_price = tob.best_bid_price;
+        }
+        if (!crossable) {
+            break;
+        }
+
+        auto consumed = book.consume_at_price(maker_side, level_price, want - total);
+        if (consumed.empty()) {
+            break;
+        }
+        for (const auto& entry : consumed) {
+            total += entry.second;
+            value += level_price * static_cast<double>(entry.second);
+            apply_maker_fill(entry.first, entry.second, level_price, tick);
+        }
+    }
+
+    if (total > 0) {
+        Price vwap = value / static_cast<double>(total);
+        fill_order(taker, total, vwap, tick, /*price_includes_impact=*/true);
+        if (fill_callback_) {
+            std::string side_str = (taker.side == Order::Side::BUY) ? "BUY" : "SELL";
+            Fill fill(taker.order_id, taker.symbol, total, vwap, tick.timestamp, side_str);
+            fill_callback_(fill);
+        }
+    }
+    return total;
+}
+
+void OrderManager::consume_trade_print(const Tick& tick) {
+    auto db_it = depth_books_.find(tick.symbol);
+    if (db_it == depth_books_.end()) {
+        return;
+    }
+    auto& book = db_it->second;
+
+    // A trade print consumes the FIFO queue resting at its price. L1 data
+    // carries no aggressor flag, so if both sides rest at the price the ask
+    // side is consumed (deterministic tiebreak).
+    Order::Side resting_side;
+    if (book.has_level(Order::Side::SELL, tick.price)) {
+        resting_side = Order::Side::SELL;
+    } else if (book.has_level(Order::Side::BUY, tick.price)) {
+        resting_side = Order::Side::BUY;
+    } else {
+        return; // Nothing resting at the trade price
+    }
+
+    auto consumed = book.consume_at_price(resting_side, tick.price, tick.volume);
+    for (const auto& entry : consumed) {
+        apply_maker_fill(entry.first, entry.second, tick.price, tick);
+    }
+}
+
+void OrderManager::apply_maker_fill(const OrderId& maker_id, Volume qty, Price price, const Tick& tick) {
+    auto it = orders_.find(maker_id);
+    if (it == orders_.end()) {
+        return; // Synthetic quote liquidity or externally seeded orders
+    }
+
+    Order& order = it->second;
+    // Passive fills execute at the resting price with no taker impact
+    fill_order(order, qty, price, tick, /*price_includes_impact=*/true);
+
+    if (fill_callback_) {
+        std::string side_str = (order.side == Order::Side::BUY) ? "BUY" : "SELL";
+        Fill fill(order.order_id, order.symbol, qty, price, tick.timestamp, side_str);
+        fill_callback_(fill);
+    }
+
+    if (order.is_filled()) {
+        limit_queue_ids_.erase(maker_id);
+        remove_order_from_book(maker_id);
+    }
 }
 
 } // namespace qse

--- a/tests/cpp/LimitQueueFillTest.cpp
+++ b/tests/cpp/LimitQueueFillTest.cpp
@@ -1,0 +1,241 @@
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "qse/order/OrderManager.h"
+
+using namespace qse;
+
+namespace {
+
+// A trade print: price and volume set, no quote sizes (so the synthetic
+// quote refresh does not add or remove displayed liquidity)
+Tick trade_tick(const std::string& symbol, Price price, Volume volume) {
+    Tick tick{};
+    tick.symbol = symbol;
+    tick.timestamp = from_unix_ms(1000);
+    tick.price = price;
+    tick.volume = volume;
+    return tick;
+}
+
+// A quote-only tick: bid/ask with displayed sizes, no trade
+Tick quote_tick(const std::string& symbol, Price bid, Volume bid_size, Price ask, Volume ask_size) {
+    Tick tick{};
+    tick.symbol = symbol;
+    tick.timestamp = from_unix_ms(1000);
+    tick.bid = bid;
+    tick.bid_size = bid_size;
+    tick.ask = ask;
+    tick.ask_size = ask_size;
+    return tick;
+}
+
+} // namespace
+
+class LimitQueueFillTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        for (const auto& f : files_) {
+            std::filesystem::remove(f);
+        }
+    }
+
+    std::unique_ptr<OrderManager> make_om(const std::string& tag) {
+        std::string eq = "lq_eq_" + tag + ".csv";
+        std::string tl = "lq_tl_" + tag + ".csv";
+        files_.push_back(eq);
+        files_.push_back(tl);
+        auto om = std::make_unique<OrderManager>(100000.0, eq, tl);
+        om->set_use_full_depth(true);
+        return om;
+    }
+
+    std::vector<std::string> files_;
+};
+
+// A3 done-when (a): an order behind the queue does not fill when a small
+// trade prints at its price
+TEST_F(LimitQueueFillTest, NoFillWhileQueueAhead) {
+    auto om = make_om("queue_ahead");
+    om->depth_book("AAPL").enqueue_order(Order::Side::SELL, 10.0, "mm_1", 300);
+
+    OrderId id = om->submit_limit_order("AAPL", Order::Side::SELL, 100, 10.0,
+                                        Order::TimeInForce::GTC);
+    // Joined the back of the queue, behind the 300 already displayed
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, id), 2u);
+
+    // A 200-share trade prints: it only chews into the queue ahead
+    om->process_tick(trade_tick("AAPL", 10.0, 200));
+
+    auto order = om->get_order(id);
+    ASSERT_TRUE(order.has_value());
+    EXPECT_EQ(order->filled_quantity, 0u);
+    EXPECT_EQ(order->status, Order::Status::PENDING);
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, id), 2u);
+}
+
+// A3 done-when (b): fills once the queue ahead is exhausted
+TEST_F(LimitQueueFillTest, FillsAfterQueueAheadExhausted) {
+    auto om = make_om("queue_fill");
+    om->depth_book("AAPL").enqueue_order(Order::Side::SELL, 10.0, "mm_1", 300);
+
+    OrderId id = om->submit_limit_order("AAPL", Order::Side::SELL, 100, 10.0,
+                                        Order::TimeInForce::GTC);
+
+    // 200 consumes queue ahead down to 100; still nothing for us
+    om->process_tick(trade_tick("AAPL", 10.0, 200));
+    // 150 finishes the 100 ahead, then reaches 50 of ours
+    om->process_tick(trade_tick("AAPL", 10.0, 150));
+
+    auto order = om->get_order(id);
+    ASSERT_TRUE(order.has_value());
+    EXPECT_EQ(order->filled_quantity, 50u);
+    EXPECT_NEAR(order->avg_fill_price, 10.0, 1e-9);
+    EXPECT_EQ(order->status, Order::Status::PARTIALLY_FILLED);
+    // We are at the head of the queue now
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, id), 1u);
+
+    // The rest fills on the next print
+    om->process_tick(trade_tick("AAPL", 10.0, 60));
+    order = om->get_order(id);
+    EXPECT_EQ(order->filled_quantity, 100u);
+    EXPECT_EQ(order->status, Order::Status::FILLED);
+}
+
+// A3 done-when (c): cancel removes the order from the queue
+TEST_F(LimitQueueFillTest, CancelRemovesFromQueue) {
+    auto om = make_om("cancel");
+    om->depth_book("AAPL").enqueue_order(Order::Side::SELL, 10.0, "mm_1", 100);
+
+    OrderId id = om->submit_limit_order("AAPL", Order::Side::SELL, 50, 10.0,
+                                        Order::TimeInForce::GTC);
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, id), 2u);
+
+    EXPECT_TRUE(om->cancel_order(id));
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, id), 0u);
+
+    // A trade big enough to have reached us fills nothing of ours
+    om->process_tick(trade_tick("AAPL", 10.0, 200));
+
+    auto order = om->get_order(id);
+    ASSERT_TRUE(order.has_value());
+    EXPECT_EQ(order->filled_quantity, 0u);
+    EXPECT_EQ(order->status, Order::Status::CANCELLED);
+}
+
+// FIFO priority among strategy orders at the same level
+TEST_F(LimitQueueFillTest, FifoAmongStrategyOrders) {
+    auto om = make_om("fifo");
+
+    OrderId first = om->submit_limit_order("AAPL", Order::Side::SELL, 50, 10.0,
+                                           Order::TimeInForce::GTC);
+    OrderId second = om->submit_limit_order("AAPL", Order::Side::SELL, 50, 10.0,
+                                            Order::TimeInForce::GTC);
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, first), 1u);
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, second), 2u);
+
+    om->process_tick(trade_tick("AAPL", 10.0, 70));
+
+    auto first_order = om->get_order(first);
+    auto second_order = om->get_order(second);
+    ASSERT_TRUE(first_order.has_value());
+    ASSERT_TRUE(second_order.has_value());
+    EXPECT_EQ(first_order->filled_quantity, 50u);
+    EXPECT_EQ(first_order->status, Order::Status::FILLED);
+    EXPECT_EQ(second_order->filled_quantity, 20u);
+    EXPECT_EQ(second_order->status, Order::Status::PARTIALLY_FILLED);
+}
+
+// A marketable limit takes liquidity up to its limit price, then rests
+TEST_F(LimitQueueFillTest, MarketableLimitTakesThenRests) {
+    auto om = make_om("marketable");
+    auto& book = om->depth_book("AAPL");
+    book.enqueue_order(Order::Side::SELL, 10.0, "mm_a", 100);
+    book.enqueue_order(Order::Side::SELL, 10.5, "mm_b", 200);
+
+    // Buy 150 limit 10.2: takes the 100 @ 10.0, will not lift 10.5,
+    // rests the remaining 50 on the bid side at 10.2
+    OrderId id = om->submit_limit_order("AAPL", Order::Side::BUY, 150, 10.2,
+                                        Order::TimeInForce::GTC);
+
+    auto order = om->get_order(id);
+    ASSERT_TRUE(order.has_value());
+    EXPECT_EQ(order->filled_quantity, 100u);
+    EXPECT_NEAR(order->avg_fill_price, 10.0, 1e-9);
+    EXPECT_EQ(order->status, Order::Status::PARTIALLY_FILLED);
+    EXPECT_EQ(book.queue_position(Order::Side::BUY, 10.2, id), 1u);
+}
+
+// An IOC limit takes what it can and never rests
+TEST_F(LimitQueueFillTest, IocTakesAndCancelsRemainder) {
+    auto om = make_om("ioc");
+    om->depth_book("AAPL").enqueue_order(Order::Side::SELL, 10.0, "mm_a", 100);
+
+    OrderId id = om->submit_limit_order("AAPL", Order::Side::BUY, 150, 10.2,
+                                        Order::TimeInForce::IOC);
+
+    auto order = om->get_order(id);
+    ASSERT_TRUE(order.has_value());
+    EXPECT_EQ(order->filled_quantity, 100u);
+    EXPECT_EQ(order->status, Order::Status::CANCELLED);
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::BUY, 10.2, id), 0u);
+}
+
+// A strategy market order consuming a resting strategy limit credits both
+// sides of the trade (fill attribution through the book)
+TEST_F(LimitQueueFillTest, MakerCreditedWhenStrategyMarketOrderConsumesIt) {
+    auto om = make_om("attribution");
+
+    OrderId maker_id = om->submit_limit_order("AAPL", Order::Side::SELL, 100, 10.0,
+                                              Order::TimeInForce::GTC);
+    OrderId taker_id = om->submit_market_order("AAPL", Order::Side::BUY, 60);
+    om->attempt_fills();
+
+    auto maker = om->get_order(maker_id);
+    auto taker = om->get_order(taker_id);
+    ASSERT_TRUE(maker.has_value());
+    ASSERT_TRUE(taker.has_value());
+
+    EXPECT_EQ(taker->filled_quantity, 60u);
+    EXPECT_NEAR(taker->avg_fill_price, 10.0, 1e-9);
+    EXPECT_EQ(taker->status, Order::Status::FILLED);
+
+    EXPECT_EQ(maker->filled_quantity, 60u);
+    EXPECT_NEAR(maker->avg_fill_price, 10.0, 1e-9);
+    EXPECT_EQ(maker->status, Order::Status::PARTIALLY_FILLED);
+    // The maker's remaining 40 still holds the front of the queue
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, maker_id), 1u);
+}
+
+// End-to-end through the tick pipeline: displayed quote size stays ahead of
+// the resting order across quote refreshes, and trade prints advance it
+TEST_F(LimitQueueFillTest, QuoteRefreshKeepsDisplayedLiquidityAhead) {
+    auto om = make_om("pipeline");
+
+    // Quote: 300 displayed at the 10.0 ask
+    om->process_tick(quote_tick("AAPL", 9.9, 500, 10.0, 300));
+
+    OrderId id = om->submit_limit_order("AAPL", Order::Side::SELL, 100, 10.0,
+                                        Order::TimeInForce::GTC);
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, id), 2u);
+
+    // A quote refresh must not let us jump ahead of displayed size
+    om->process_tick(quote_tick("AAPL", 9.9, 500, 10.0, 300));
+    EXPECT_EQ(om->depth_book("AAPL").queue_position(Order::Side::SELL, 10.0, id), 2u);
+
+    // A 350 trade consumes the 300 displayed, then 50 of ours
+    om->process_tick(trade_tick("AAPL", 10.0, 350));
+    auto order = om->get_order(id);
+    ASSERT_TRUE(order.has_value());
+    EXPECT_EQ(order->filled_quantity, 50u);
+    EXPECT_EQ(order->status, Order::Status::PARTIALLY_FILLED);
+
+    // The remainder fills on the next print
+    om->process_tick(trade_tick("AAPL", 10.0, 50));
+    order = om->get_order(id);
+    EXPECT_EQ(order->filled_quantity, 100u);
+    EXPECT_EQ(order->status, Order::Status::FILLED);
+}


### PR DESCRIPTION
## What

Adds queue-position-aware limit order fills to the full-depth fill model (A3 in docs/TASK_BREAKDOWN.md), plus a CI maintenance bump (actions/checkout v4 -> v5 for the Node 20 deprecation warning).

- `submit_limit_order` takes any marketable portion immediately (capped walk up to the limit price, VWAP fill), then rests the remainder at the back of the FIFO queue at its price level; IOC never rests
- Trade prints consume the FIFO queue at their price *before* the quote refresh, so resting orders fill only after the displayed queue ahead of them is exhausted
- Synthetic quote liquidity is re-inserted at the *front* of its level on each refresh: with L1 data the real queue is invisible, so displayed size is conservatively assumed to be ahead of strategy orders
- `cancel_order` pulls the order out of the book queue
- New `OrderBookFullDepth::consume_at_price` reports which resting orders a fill consumed, so maker fills are credited even when one strategy order trades against another (closes an A2 gap where market orders could silently consume resting strategy orders); all full-depth fills emit the fill callback

## Why

Third chunk of the microstructure track: with A1 (full-depth FIFO book) and A2 (impact-priced market orders) in, this makes passive executions realistic too - limit orders wait in queue instead of filling instantly on a price touch. It completes the simulation core needed for the fixed-slippage vs microstructure-realism comparison experiments.

## Reviewer notes

- The "displayed size re-queues at the front" rule is a deliberate conservative modeling choice for L1 data, documented inline in `OrderBookFullDepth::on_tick`
- Trade prints carry no aggressor flag; if both sides rest at the print price, the ask side is consumed (deterministic tiebreak in `consume_trade_print`)
- Self-trades are allowed (no self-trade prevention) - both sides get credited
- Tests: `LimitQueueFillTest` (8 cases) covers the A3 done-when criteria - no fill while queue ahead, fill after queue exhausted, cancel removes from queue - plus FIFO priority, marketable-limit take-then-rest, IOC, maker/taker attribution, and queue persistence across quote refreshes
- Verified before pushing: 207/207 ctest in an ubuntu:24.04 CI-replica container, 204/204 on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
