### PR TITLE
feat(analysis): institutional tearsheet + engine output fixes

### DIFF
--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -16,7 +16,7 @@ bottom within a track; tracks are mostly independent of each other.
 | 4.2 Factor model | ✅ Done **far beyond spec**: MultiFactorCalculator, UniverseFilter, CrossSectionalRegression, ICMonitor, AlphaBlender, RiskModel, PortfolioBuilder (QP), FactorExecutionEngine, rebalance guard, YAML config |
 | 4.3 Portfolio optimizer | ✅ Mostly done (constrained QP exists); mean-variance extension optional (A5) |
 | **OrderBookFullDepth** | ✅ Committed 2026-07-04: all 38 tests pass (PriceLevel, QueuePosition, Impact) |
-| 5 Data & tearsheet | ❌ analyze.py has only Sharpe + max drawdown; no ffill, no corporate actions, no PDF |
+| 5 Data & tearsheet | 🟡 B3 tearsheet done 2026-07-05; B1 (ffill) and B2 (corporate actions) remain |
 | 6 CI / format / lint | 🟡 CI green as of 2026-07-04 (C1+C4 done); formatting (C2) and clang-tidy (C3) remain |
 | 7 Live trading | ❌ Not started |
 | 8 Presentation | ❌ Not started |
@@ -85,13 +85,14 @@ bottom within a track; tracks are mostly independent of each other.
   shows pre-split prices ÷4, volumes ×4, and an equity curve unchanged across
   the split date for a buy-and-hold backtest.
 
-### B3. Institutional tearsheet
-- Extend `scripts/analysis/analyze.py`: Calmar, annualized turnover, rolling
-  Sharpe (63d window) plot, benchmark-relative plot vs SPY with alpha/beta
-  regression, PDF export (matplotlib `PdfPages` is enough).
-- **Done when:** pytest feeds a synthetic equity curve with hand-computed
-  Sharpe/Calmar/turnover and asserts each metric to 4 decimals; running on a
-  real backtest emits `tearsheet.pdf`.
+### B3. ✅ Institutional tearsheet (done 2026-07-05)
+- Landed as `scripts/analysis/tearsheet.py` (new module instead of extending
+  analyze.py): Calmar, annualized turnover, rolling Sharpe, alpha/beta
+  regression vs benchmark, 3-page PDF via PdfPages; 16 pytest cases with
+  hand-computed metrics in `tests/python/test_tearsheet.py`.
+- Fixed along the way: Backtester never called `record_equity` (all equity
+  CSVs were header-only), and three failbit hacks suppressed stdout in every
+  qse binary — debug logging is now opt-in via `QSE_DEBUG=1` (Debug.h).
 
 ---
 

--- a/include/qse/core/Debug.h
+++ b/include/qse/core/Debug.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdlib>
+
+namespace qse {
+
+/**
+ * @brief Opt-in debug tracing, enabled by setting QSE_DEBUG=1 in the
+ * environment. Hot-path logging must be gated on this check; suppressing
+ * stdout globally (the old failbit hack) breaks every binary linking qse.
+ */
+inline bool qse_debug_enabled() {
+    static const bool enabled = std::getenv("QSE_DEBUG") != nullptr;
+    return enabled;
+}
+
+} // namespace qse

--- a/scripts/analysis/tearsheet.py
+++ b/scripts/analysis/tearsheet.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Institutional performance tearsheet (roadmap B3).
+
+Pure metric functions (Sharpe, max drawdown, CAGR, Calmar, turnover, rolling
+Sharpe, alpha/beta vs a benchmark) over engine output CSVs, plus a multi-page
+PDF report built with matplotlib PdfPages.
+
+Engine formats supported:
+    equity:   timestamp,equity        (current)  or timestamp,portfolio_value
+    tradelog: timestamp,symbol,type,quantity,price,cash  (current)
+              or timestamp,type,price,quantity,commission (legacy)
+    benchmark: date-indexed OHLCV CSV (e.g. data/raw_AAPL.csv); close is used
+
+Usage (from the repo root):
+    python scripts/analysis/tearsheet.py --equity equity_curve.csv \
+        --tradelog tradelog.csv --benchmark data/raw_AAPL.csv \
+        --out results/tearsheet.pdf --title "SMA 20/50 AAPL"
+"""
+
+import argparse
+import datetime
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.backends.backend_pdf import PdfPages
+
+TRADING_DAYS = 252
+ROLLING_WINDOW = 63
+
+
+# ---------------------------------------------------------------------------
+# Metrics (pure functions, unit-tested in tests/python/test_tearsheet.py)
+# ---------------------------------------------------------------------------
+
+def daily_returns(equity: pd.Series) -> pd.Series:
+    """Simple returns between consecutive equity observations."""
+    return equity.pct_change().dropna()
+
+
+def annualized_sharpe(returns: pd.Series, risk_free_rate: float = 0.0,
+                      periods: int = TRADING_DAYS) -> float:
+    """Annualized Sharpe ratio of per-period returns (sample std, ddof=1)."""
+    if len(returns) < 2:
+        return 0.0
+    excess = returns - risk_free_rate / periods
+    std = excess.std(ddof=1)
+    if std == 0 or np.isnan(std):
+        return 0.0
+    return float(excess.mean() / std * np.sqrt(periods))
+
+
+def max_drawdown(equity: pd.Series) -> float:
+    """Largest peak-to-trough decline as a negative fraction (0 = no loss)."""
+    if len(equity) == 0:
+        return 0.0
+    peak = equity.cummax()
+    return float(((equity - peak) / peak).min())
+
+
+def cagr(equity: pd.Series, periods: int = TRADING_DAYS) -> float:
+    """Compound annual growth rate, with len-1 observations = one period."""
+    n = len(equity) - 1
+    if n <= 0 or equity.iloc[0] <= 0:
+        return 0.0
+    years = n / periods
+    return float((equity.iloc[-1] / equity.iloc[0]) ** (1.0 / years) - 1.0)
+
+
+def calmar_ratio(equity: pd.Series, periods: int = TRADING_DAYS) -> float:
+    """CAGR over absolute max drawdown; 0.0 when there is no drawdown."""
+    mdd = max_drawdown(equity)
+    if mdd == 0:
+        return 0.0
+    return cagr(equity, periods) / abs(mdd)
+
+
+def annualized_turnover(trades: pd.DataFrame, equity: pd.Series,
+                        periods: int = TRADING_DAYS) -> float:
+    """Traded notional (|quantity| * price, single-counted) over mean equity,
+    per year of the equity history."""
+    n = len(equity) - 1
+    if n <= 0 or trades is None or len(trades) == 0:
+        return 0.0
+    notional = float((trades["quantity"].abs() * trades["price"]).sum())
+    years = n / periods
+    return notional / float(equity.mean()) / years
+
+
+def rolling_sharpe(returns: pd.Series, window: int = ROLLING_WINDOW,
+                   periods: int = TRADING_DAYS) -> pd.Series:
+    """Annualized Sharpe over a rolling window of per-period returns."""
+    mean = returns.rolling(window).mean()
+    std = returns.rolling(window).std(ddof=1)
+    return mean / std * np.sqrt(periods)
+
+
+def alpha_beta(strategy_returns: pd.Series, benchmark_returns: pd.Series,
+               periods: int = TRADING_DAYS) -> tuple[float, float]:
+    """OLS regression strategy = alpha + beta * benchmark on the aligned
+    overlap. Returns (annualized alpha, beta); (nan, nan) if the overlap is
+    too short to regress."""
+    df = pd.concat([strategy_returns, benchmark_returns], axis=1,
+                   join="inner").dropna()
+    if len(df) < 3:
+        return (float("nan"), float("nan"))
+    y = df.iloc[:, 0].to_numpy(dtype=float)
+    x = df.iloc[:, 1].to_numpy(dtype=float)
+    beta, alpha_per_period = np.polyfit(x, y, 1)
+    return (float(alpha_per_period * periods), float(beta))
+
+
+# ---------------------------------------------------------------------------
+# Loaders
+# ---------------------------------------------------------------------------
+
+def _parse_timestamps(ts: pd.Series) -> pd.Index:
+    """Epoch timestamps of any resolution -> DatetimeIndex; non-numeric values
+    are parsed as date strings; small integers are kept as a plain index
+    (bar counters from old runs)."""
+    if pd.api.types.is_numeric_dtype(ts):
+        mx = float(ts.max())
+        for threshold, unit in ((1e17, "ns"), (1e14, "us"), (1e11, "ms"), (1e8, "s")):
+            if mx > threshold:
+                return pd.to_datetime(ts, unit=unit)
+        return pd.Index(ts)
+    return pd.to_datetime(ts)
+
+
+def load_equity(path: str) -> pd.Series:
+    df = pd.read_csv(path)
+    value_col = next((c for c in ("equity", "portfolio_value", "value")
+                      if c in df.columns), None)
+    if value_col is None:
+        raise ValueError(f"No equity column in {path}; columns: {list(df.columns)}")
+    series = pd.Series(df[value_col].to_numpy(dtype=float),
+                       index=_parse_timestamps(df["timestamp"]), name="equity")
+    # Keep the last observation per timestamp (intraday duplicates)
+    series = series[~series.index.duplicated(keep="last")].sort_index()
+    return series
+
+
+def load_tradelog(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    if "quantity" not in df.columns or "price" not in df.columns:
+        raise ValueError(f"Tradelog {path} needs quantity and price columns")
+    return df
+
+
+def load_benchmark(path: str) -> pd.Series:
+    df = pd.read_csv(path, index_col=0, parse_dates=True)
+    if "close" not in df.columns:
+        raise ValueError(f"Benchmark {path} needs a close column")
+    return df["close"].dropna().sort_index()
+
+
+def to_daily(equity: pd.Series) -> pd.Series:
+    """Last observation per calendar day for datetime-indexed curves;
+    non-datetime curves are returned unchanged."""
+    if isinstance(equity.index, pd.DatetimeIndex):
+        return equity.resample("1D").last().dropna()
+    return equity
+
+
+# ---------------------------------------------------------------------------
+# Tearsheet PDF
+# ---------------------------------------------------------------------------
+
+def compute_summary(equity: pd.Series, trades: pd.DataFrame | None,
+                    benchmark: pd.Series | None,
+                    periods: int = TRADING_DAYS) -> dict:
+    returns = daily_returns(equity)
+    summary = {
+        "Observations": len(equity),
+        "Total return": equity.iloc[-1] / equity.iloc[0] - 1.0,
+        "CAGR": cagr(equity, periods),
+        "Volatility (ann.)": float(returns.std(ddof=1) * np.sqrt(periods))
+        if len(returns) > 1 else 0.0,
+        "Sharpe (ann.)": annualized_sharpe(returns, periods=periods),
+        "Max drawdown": max_drawdown(equity),
+        "Calmar": calmar_ratio(equity, periods),
+    }
+    if trades is not None and len(trades) > 0:
+        summary["Trades"] = len(trades)
+        summary["Turnover (ann.)"] = annualized_turnover(trades, equity, periods)
+    if benchmark is not None:
+        bench_returns = daily_returns(benchmark)
+        alpha, beta = alpha_beta(returns, bench_returns, periods)
+        summary["Alpha (ann.)"] = alpha
+        summary["Beta"] = beta
+    return summary
+
+
+def _format_value(key: str, value) -> str:
+    if isinstance(value, int):
+        return f"{value:,}"
+    percent_keys = ("return", "CAGR", "Volatility", "drawdown", "Alpha")
+    if any(k.lower() in key.lower() for k in percent_keys):
+        return f"{value * 100:.2f}%"
+    return f"{value:.3f}"
+
+
+def build_tearsheet(equity: pd.Series, trades: pd.DataFrame | None,
+                    benchmark: pd.Series | None, out_path: str,
+                    title: str = "Strategy") -> dict:
+    """Render the multi-page PDF and return the summary metrics."""
+    daily = to_daily(equity)
+    returns = daily_returns(daily)
+    summary = compute_summary(daily, trades, benchmark)
+
+    bench_daily = to_daily(benchmark) if benchmark is not None else None
+    if bench_daily is not None and isinstance(daily.index, pd.DatetimeIndex):
+        bench_daily = bench_daily.loc[
+            (bench_daily.index >= daily.index.min())
+            & (bench_daily.index <= daily.index.max())]
+        if bench_daily.empty:
+            bench_daily = None
+
+    with PdfPages(out_path) as pdf:
+        # Page 1: equity, drawdown, summary table
+        fig, axes = plt.subplots(3, 1, figsize=(8.5, 11),
+                                 gridspec_kw={"height_ratios": [3, 2, 2]})
+        fig.suptitle(f"Performance Tearsheet — {title}", fontsize=14)
+
+        axes[0].plot(daily.index, daily.values, color="tab:blue")
+        axes[0].set_title("Equity curve")
+        axes[0].grid(alpha=0.3)
+
+        drawdown = (daily - daily.cummax()) / daily.cummax()
+        axes[1].fill_between(daily.index, drawdown.values, 0, color="tab:red",
+                             alpha=0.4)
+        axes[1].set_title("Drawdown")
+        axes[1].grid(alpha=0.3)
+
+        axes[2].axis("off")
+        rows = [[k, _format_value(k, v)] for k, v in summary.items()]
+        table = axes[2].table(cellText=rows, colLabels=["Metric", "Value"],
+                              loc="center", cellLoc="left")
+        table.auto_set_font_size(False)
+        table.set_fontsize(9)
+        table.scale(1.0, 1.3)
+        fig.tight_layout(rect=(0, 0, 1, 0.96))
+        pdf.savefig(fig)
+        plt.close(fig)
+
+        # Page 2: rolling Sharpe and return distribution
+        fig, axes = plt.subplots(2, 1, figsize=(8.5, 11))
+        window = ROLLING_WINDOW
+        if len(returns) < 2 * window:
+            window = max(5, len(returns) // 4)
+        rs = rolling_sharpe(returns, window=window)
+        axes[0].plot(rs.index, rs.values, color="tab:green")
+        axes[0].axhline(0.0, color="gray", lw=0.8)
+        axes[0].set_title(f"Rolling Sharpe ({window}-period window, annualized)")
+        axes[0].grid(alpha=0.3)
+
+        axes[1].hist(returns.values, bins=50, color="tab:blue", alpha=0.7)
+        axes[1].axvline(float(returns.mean()), color="tab:red", lw=1.0,
+                        label=f"mean {returns.mean() * 1e4:.1f} bps")
+        axes[1].set_title("Daily return distribution")
+        axes[1].legend()
+        axes[1].grid(alpha=0.3)
+        fig.tight_layout()
+        pdf.savefig(fig)
+        plt.close(fig)
+
+        # Page 3: benchmark-relative view
+        if bench_daily is not None and len(bench_daily) >= 3:
+            bench_returns = daily_returns(bench_daily)
+            fig, axes = plt.subplots(2, 1, figsize=(8.5, 11))
+
+            strat_rebased = daily / daily.iloc[0]
+            bench_rebased = bench_daily / bench_daily.iloc[0]
+            axes[0].plot(strat_rebased.index, strat_rebased.values,
+                         label="strategy", color="tab:blue")
+            axes[0].plot(bench_rebased.index, bench_rebased.values,
+                         label="benchmark (buy & hold)", color="tab:gray")
+            axes[0].set_title("Growth of $1 vs benchmark")
+            axes[0].legend()
+            axes[0].grid(alpha=0.3)
+
+            aligned = pd.concat([returns, bench_returns], axis=1,
+                                join="inner").dropna()
+            if len(aligned) >= 3:
+                y = aligned.iloc[:, 0].to_numpy(dtype=float)
+                x = aligned.iloc[:, 1].to_numpy(dtype=float)
+                beta, alpha_daily = np.polyfit(x, y, 1)
+                axes[1].scatter(x, y, s=12, alpha=0.6, color="tab:blue")
+                grid = np.linspace(x.min(), x.max(), 50)
+                axes[1].plot(grid, alpha_daily + beta * grid, color="tab:red",
+                             label=(f"alpha {alpha_daily * TRADING_DAYS * 100:.2f}%/yr, "
+                                    f"beta {beta:.2f}"))
+                axes[1].set_xlabel("Benchmark daily return")
+                axes[1].set_ylabel("Strategy daily return")
+                axes[1].set_title("Return regression vs benchmark")
+                axes[1].legend()
+                axes[1].grid(alpha=0.3)
+            fig.tight_layout()
+            pdf.savefig(fig)
+            plt.close(fig)
+
+        meta = pdf.infodict()
+        meta["Title"] = f"Tearsheet - {title}"
+        meta["CreationDate"] = datetime.datetime.now()
+
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--equity", required=True, help="Equity curve CSV")
+    parser.add_argument("--tradelog", help="Trade log CSV")
+    parser.add_argument("--benchmark", help="Benchmark OHLCV CSV (close used)")
+    parser.add_argument("--out", default="tearsheet.pdf", help="Output PDF path")
+    parser.add_argument("--title", default="Strategy", help="Report title")
+    args = parser.parse_args()
+
+    equity = load_equity(args.equity)
+    if len(equity) < 2:
+        print(f"Equity curve {args.equity} has fewer than 2 points", file=sys.stderr)
+        return 1
+    trades = load_tradelog(args.tradelog) if args.tradelog else None
+    benchmark = load_benchmark(args.benchmark) if args.benchmark else None
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    summary = build_tearsheet(equity, trades, benchmark, args.out, args.title)
+
+    print(f"Wrote {args.out}")
+    width = max(len(k) for k in summary)
+    for key, value in summary.items():
+        print(f"  {key:<{width}}  {_format_value(key, value)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/Backtester.cpp
+++ b/src/core/Backtester.cpp
@@ -71,6 +71,7 @@ void Backtester::run() {
     });
 
     bool abort_due_to_error = false;
+    std::map<std::string, double> last_prices;
     for (const auto& tick : all_ticks) {
         if (abort_due_to_error) break;
 
@@ -103,6 +104,14 @@ void Backtester::run() {
         if (order_manager_) {
             order_manager_->process_tick(tick);
             order_manager_->attempt_fills();
+
+            // Mark the portfolio to market so the equity curve gets a point
+            // per tick (valued at the latest price seen for each symbol)
+            last_prices[tick.symbol] = tick.price;
+            auto ts_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             tick.timestamp.time_since_epoch())
+                             .count();
+            order_manager_->record_equity(ts_ms, last_prices);
         }
     }
     

--- a/src/data/BarBuilder.cpp
+++ b/src/data/BarBuilder.cpp
@@ -1,11 +1,7 @@
 #include "qse/data/BarBuilder.h"
+#include "qse/core/Debug.h"
 #include <algorithm> // for std::max/min
 #include <iostream>
-
-#ifndef QSE_ENABLE_VERBOSE
-// Disable all std::cout in this TU for performance
-static struct DisableBarBuilderCout { DisableBarBuilderCout(){ std::cout.setstate(std::ios_base::failbit); } } _disable_bb_cout;
-#endif
 
 namespace qse {
 
@@ -15,7 +11,7 @@ BarBuilder::BarBuilder(const std::chrono::seconds& bar_interval)
 
 // Add a tick, then if any completed bars are queued, pop & return one.
 std::optional<Bar> BarBuilder::add_tick(const Tick& tick) {
-    std::cout << "Adding tick: timestamp=" << tick.timestamp.time_since_epoch().count() 
+    if (qse_debug_enabled()) std::cout << "Adding tick: timestamp=" << tick.timestamp.time_since_epoch().count() 
               << ", price=" << tick.price << ", volume=" << tick.volume << std::endl;
     
     // 1) buffer + sort
@@ -23,18 +19,18 @@ std::optional<Bar> BarBuilder::add_tick(const Tick& tick) {
     std::sort(tick_buffer_.begin(), tick_buffer_.end(),
               [](auto &a, auto &b){ return a.timestamp < b.timestamp; });
 
-    std::cout << "Buffer size after sort: " << tick_buffer_.size() << std::endl;
+    if (qse_debug_enabled()) std::cout << "Buffer size after sort: " << tick_buffer_.size() << std::endl;
 
     // 2) process everything
     process_buffered_ticks();
 
-    std::cout << "Ready bars queue size: " << ready_bars_.size() << std::endl;
+    if (qse_debug_enabled()) std::cout << "Ready bars queue size: " << ready_bars_.size() << std::endl;
 
     // 3) if there's a ready bar, return the oldest
     if (!ready_bars_.empty()) {
         Bar b = ready_bars_.front();
         ready_bars_.pop_front();
-        std::cout << "Returning bar: timestamp=" << b.timestamp.time_since_epoch().count() 
+        if (qse_debug_enabled()) std::cout << "Returning bar: timestamp=" << b.timestamp.time_since_epoch().count() 
                   << ", open=" << b.open << ", high=" << b.high 
                   << ", low=" << b.low << ", close=" << b.close 
                   << ", volume=" << b.volume << std::endl;
@@ -46,12 +42,12 @@ std::optional<Bar> BarBuilder::add_tick(const Tick& tick) {
 // Flush any remaining: first finish processing ticks, then
 // return any bars left (one per call).
 std::optional<Bar> BarBuilder::flush() {
-    std::cout << "Flush called, ready bars: " << ready_bars_.size() << std::endl;
+    if (qse_debug_enabled()) std::cout << "Flush called, ready bars: " << ready_bars_.size() << std::endl;
     process_buffered_ticks();
     if (!ready_bars_.empty()) {
         Bar b = ready_bars_.front();
         ready_bars_.pop_front();
-        std::cout << "Flush returning bar: timestamp=" << b.timestamp.time_since_epoch().count() 
+        if (qse_debug_enabled()) std::cout << "Flush returning bar: timestamp=" << b.timestamp.time_since_epoch().count() 
                   << ", open=" << b.open << ", high=" << b.high 
                   << ", low=" << b.low << ", close=" << b.close 
                   << ", volume=" << b.volume << std::endl;
@@ -61,7 +57,7 @@ std::optional<Bar> BarBuilder::flush() {
     if (current_bar_) {
         Bar b = *current_bar_;
         current_bar_.reset();
-        std::cout << "Flush returning current bar: timestamp=" << b.timestamp.time_since_epoch().count() 
+        if (qse_debug_enabled()) std::cout << "Flush returning current bar: timestamp=" << b.timestamp.time_since_epoch().count() 
                   << ", open=" << b.open << ", high=" << b.high 
                   << ", low=" << b.low << ", close=" << b.close 
                   << ", volume=" << b.volume << std::endl;
@@ -72,54 +68,54 @@ std::optional<Bar> BarBuilder::flush() {
 
 // Internal: walk through all buffered ticks, emitting bars on each boundary.
 void BarBuilder::process_buffered_ticks() {
-    std::cout << "Processing " << tick_buffer_.size() << " buffered ticks" << std::endl;
+    if (qse_debug_enabled()) std::cout << "Processing " << tick_buffer_.size() << " buffered ticks" << std::endl;
     
     while (!tick_buffer_.empty()) {
         const auto tick = tick_buffer_.front();
         tick_buffer_.erase(tick_buffer_.begin());
 
-        std::cout << "Processing tick: timestamp=" << tick.timestamp.time_since_epoch().count() 
+        if (qse_debug_enabled()) std::cout << "Processing tick: timestamp=" << tick.timestamp.time_since_epoch().count() 
                   << ", price=" << tick.price << std::endl;
 
         // first-ever tick: start first bar
         if (!current_bar_) {
-            std::cout << "Starting first bar" << std::endl;
+            if (qse_debug_enabled()) std::cout << "Starting first bar" << std::endl;
             start_new_bar(tick);
             continue;
         }
 
         // if tick falls beyond current interval, possibly multiple intervals:
         auto bucket_end = current_bar_start_time_ + bar_interval_;
-        std::cout << "Current bar start: " << current_bar_start_time_.time_since_epoch().count() 
+        if (qse_debug_enabled()) std::cout << "Current bar start: " << current_bar_start_time_.time_since_epoch().count() 
                   << ", bucket end: " << bucket_end.time_since_epoch().count() 
                   << ", tick timestamp: " << tick.timestamp.time_since_epoch().count() << std::endl;
         
         if (tick.timestamp >= bucket_end) {
             // emit current
-            std::cout << "Emitting current bar to ready queue" << std::endl;
+            if (qse_debug_enabled()) std::cout << "Emitting current bar to ready queue" << std::endl;
             ready_bars_.push_back(*current_bar_);
 
             // advance start by exactly one interval at a time
             // until the tick fits into [start, start+interval)
             do {
                 current_bar_start_time_ += bar_interval_;
-                std::cout << "Advanced bar start to: " << current_bar_start_time_.time_since_epoch().count() << std::endl;
+                if (qse_debug_enabled()) std::cout << "Advanced bar start to: " << current_bar_start_time_.time_since_epoch().count() << std::endl;
             } while (tick.timestamp >= current_bar_start_time_ + bar_interval_);
 
             // start a new bar at that aligned start, initialised with this tick
-            std::cout << "Starting new bar" << std::endl;
+            if (qse_debug_enabled()) std::cout << "Starting new bar" << std::endl;
             start_new_bar(tick);
         } else if (tick.timestamp < current_bar_start_time_) {
             // tick is before current bar start: emit current bar and start new one
-            std::cout << "Tick before current bar start, emitting current bar" << std::endl;
+            if (qse_debug_enabled()) std::cout << "Tick before current bar start, emitting current bar" << std::endl;
             ready_bars_.push_back(*current_bar_);
             
             // start a new bar at the correct time bucket for this tick
-            std::cout << "Starting new bar for earlier tick" << std::endl;
+            if (qse_debug_enabled()) std::cout << "Starting new bar for earlier tick" << std::endl;
             start_new_bar(tick);
         } else {
             // same interval: update OHLCV
-            std::cout << "Updating current bar" << std::endl;
+            if (qse_debug_enabled()) std::cout << "Updating current bar" << std::endl;
             current_bar_->high   = std::max(current_bar_->high,  tick.price);
             current_bar_->low    = std::min(current_bar_->low,   tick.price);
             current_bar_->close  = tick.price;
@@ -136,7 +132,7 @@ void BarBuilder::start_new_bar(const Tick& tick) {
     auto start_secs = (secs.count() / interval) * interval;
     current_bar_start_time_ = Timestamp(std::chrono::seconds(start_secs));
 
-    std::cout << "Starting new bar at: " << current_bar_start_time_.time_since_epoch().count() 
+    if (qse_debug_enabled()) std::cout << "Starting new bar at: " << current_bar_start_time_.time_since_epoch().count() 
               << " for tick at: " << tick.timestamp.time_since_epoch().count() << std::endl;
 
     // Bar has a user-declared constructor, so it is not an aggregate and

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -22,7 +22,7 @@ int main() {
         
         // --- Create Components ---
         std::cout << "Initializing components..." << std::endl;
-        auto data_reader = std::make_unique<qse::CSVDataReader>(data_file);
+        auto data_reader = std::make_unique<qse::CSVDataReader>(data_file, symbol);
         auto order_manager = std::make_unique<qse::OrderManager>(
             initial_capital, 
             "equity_curve.csv", 

--- a/src/messaging/TickPublisher.cpp
+++ b/src/messaging/TickPublisher.cpp
@@ -1,11 +1,8 @@
 #include "qse/messaging/TickPublisher.h"
+#include "qse/core/Debug.h"
 #include <iostream>
 #include <sstream>
 #include <chrono>
-
-#ifndef QSE_ENABLE_VERBOSE
-static struct DisablePublisherCout { DisablePublisherCout(){ std::cout.setstate(std::ios_base::failbit); } } _disable_pub_cout;
-#endif
 
 constexpr int ZMQ_HWM       = 100000;
 constexpr int ZMQ_BUF_SIZE  = 4 * 1024 * 1024;
@@ -20,7 +17,7 @@ TickPublisher::TickPublisher(const std::string& endpoint)
         socket_->set(zmq::sockopt::sndhwm,  ZMQ_HWM);
         socket_->set(zmq::sockopt::sndbuf, ZMQ_BUF_SIZE);
         socket_->bind(endpoint_);
-        std::cout << "TickPublisher bound to: " << endpoint_ << std::endl;
+        if (qse_debug_enabled()) std::cout << "TickPublisher bound to: " << endpoint_ << std::endl;
     } catch (const zmq::error_t& e) {
         std::cerr << "Failed to initialize TickPublisher: " << e.what() << std::endl;
         throw;
@@ -40,8 +37,8 @@ void TickPublisher::publish_tick(const std::string& topic, const Tick& tick) {
     try {
         std::string serialized = serialize_tick(tick);
         
-        std::cout << "[PUBLISHER] Sending " << topic.size() << "-byte topic: '" << topic << "'" << std::endl;
-        std::cout << "[PUBLISHER] Sending " << serialized.size() << "-byte payload." << std::endl;
+        if (qse_debug_enabled()) std::cout << "[PUBLISHER] Sending " << topic.size() << "-byte topic: '" << topic << "'" << std::endl;
+        if (qse_debug_enabled()) std::cout << "[PUBLISHER] Sending " << serialized.size() << "-byte payload." << std::endl;
         
         zmq::message_t topic_msg(topic.data(), topic.size());
         zmq::message_t data_msg(serialized.data(), serialized.size());
@@ -49,7 +46,7 @@ void TickPublisher::publish_tick(const std::string& topic, const Tick& tick) {
         socket_->send(topic_msg, zmq::send_flags::sndmore);
         socket_->send(data_msg, zmq::send_flags::none);
         
-        std::cout << "Published tick: price=" << tick.price 
+        if (qse_debug_enabled()) std::cout << "Published tick: price=" << tick.price 
                   << ", volume=" << tick.volume << std::endl;
     } catch (const zmq::error_t& e) {
         std::cerr << "Failed to publish tick: " << e.what() << std::endl;
@@ -60,8 +57,8 @@ void TickPublisher::publish_bar(const std::string& topic, const Bar& bar) {
     try {
         std::string serialized = serialize_bar(bar);
         
-        std::cout << "[PUBLISHER] Sending " << topic.size() << "-byte topic: '" << topic << "'" << std::endl;
-        std::cout << "[PUBLISHER] Sending " << serialized.size() << "-byte payload." << std::endl;
+        if (qse_debug_enabled()) std::cout << "[PUBLISHER] Sending " << topic.size() << "-byte topic: '" << topic << "'" << std::endl;
+        if (qse_debug_enabled()) std::cout << "[PUBLISHER] Sending " << serialized.size() << "-byte payload." << std::endl;
         
         zmq::message_t topic_msg(topic.data(), topic.size());
         zmq::message_t data_msg(serialized.data(), serialized.size());
@@ -69,7 +66,7 @@ void TickPublisher::publish_bar(const std::string& topic, const Bar& bar) {
         socket_->send(topic_msg, zmq::send_flags::sndmore);
         socket_->send(data_msg, zmq::send_flags::none);
         
-        std::cout << "Published bar: " << bar.symbol 
+        if (qse_debug_enabled()) std::cout << "Published bar: " << bar.symbol 
                   << " O:" << bar.open << " H:" << bar.high 
                   << " L:" << bar.low << " C:" << bar.close << std::endl;
     } catch (const zmq::error_t& e) {
@@ -86,7 +83,7 @@ void TickPublisher::publish_order(const std::string& topic, const Order& order) 
         socket_->send(topic_msg, zmq::send_flags::sndmore);
         socket_->send(data_msg, zmq::send_flags::none);
         
-        std::cout << "Published order: " << order.order_id 
+        if (qse_debug_enabled()) std::cout << "Published order: " << order.order_id 
                   << " " << order.symbol << std::endl;
     } catch (const zmq::error_t& e) {
         std::cerr << "Failed to publish order: " << e.what() << std::endl;

--- a/src/order/OrderManager.cpp
+++ b/src/order/OrderManager.cpp
@@ -1,14 +1,11 @@
 #include "qse/order/OrderManager.h"
+#include "qse/core/Debug.h"
 #include "qse/data/Data.h" // Required for the Trade struct
 
 #include <iostream>
 #include <stdexcept>
 #include <chrono>
 #include <algorithm>
-
-#ifndef QSE_ENABLE_VERBOSE
-static struct DisableOrderMgrCout { DisableOrderMgrCout(){ std::cout.setstate(std::ios_base::failbit);} } _disable_om_cout;
-#endif
 
 namespace qse {
 
@@ -274,7 +271,7 @@ void OrderManager::process_tick(const Tick& tick) {
     // Use the tick's symbol for order matching
     std::string symbol = tick.symbol;
     
-    std::cout << "DEBUG: Processing tick for " << symbol << " bid=" << tick.bid << " ask=" << tick.ask << " mid=" << tick.mid_price() << std::endl;
+    if (qse_debug_enabled()) std::cout << "DEBUG: Processing tick for " << symbol << " bid=" << tick.bid << " ask=" << tick.ask << " mid=" << tick.mid_price() << std::endl;
     
     // Match orders for this symbol first
     match_orders_for_symbol(symbol, tick);
@@ -347,14 +344,14 @@ void OrderManager::remove_order_from_book(const OrderId& order_id) {
 void OrderManager::match_orders_for_symbol(const std::string& symbol, const Tick& tick) {
     auto symbol_it = symbol_orders_.find(symbol);
     if (symbol_it == symbol_orders_.end()) {
-        std::cout << "DEBUG: No orders found for symbol " << symbol << std::endl;
+        if (qse_debug_enabled()) std::cout << "DEBUG: No orders found for symbol " << symbol << std::endl;
         return;
     }
     
     // Iterate a copy: maker fills triggered inside the loop can remove
     // entries from symbol_orders_ and invalidate references into it
     std::vector<OrderId> order_ids = symbol_it->second;
-    std::cout << "DEBUG: Found " << order_ids.size() << " orders for symbol " << symbol << std::endl;
+    if (qse_debug_enabled()) std::cout << "DEBUG: Found " << order_ids.size() << " orders for symbol " << symbol << std::endl;
     std::vector<OrderId> to_remove;
     
     // Get current top of book from whichever book model is active
@@ -376,11 +373,11 @@ void OrderManager::match_orders_for_symbol(const std::string& symbol, const Tick
         
         Order& order = order_it->second;
         if (!order.is_active()) {
-            std::cout << "DEBUG: Order " << order_id << " is not active, status=" << static_cast<int>(order.status) << std::endl;
+            if (qse_debug_enabled()) std::cout << "DEBUG: Order " << order_id << " is not active, status=" << static_cast<int>(order.status) << std::endl;
             continue;
         }
         
-        std::cout << "DEBUG: Processing order " << order_id << " type=" << static_cast<int>(order.type) << " side=" << static_cast<int>(order.side) << " qty=" << order.quantity << std::endl;
+        if (qse_debug_enabled()) std::cout << "DEBUG: Processing order " << order_id << " type=" << static_cast<int>(order.type) << " side=" << static_cast<int>(order.side) << " qty=" << order.quantity << std::endl;
         
         Volume fill_qty = 0;
         Price fill_price = 0.0;
@@ -416,7 +413,7 @@ void OrderManager::match_orders_for_symbol(const std::string& symbol, const Tick
                 fill_qty = std::min(order.remaining_quantity(), tick.volume);
                 fill_price = tick.mid_price();
             }
-            std::cout << "DEBUG: Market order fill_qty=" << fill_qty << " at " << fill_price << std::endl;
+            if (qse_debug_enabled()) std::cout << "DEBUG: Market order fill_qty=" << fill_qty << " at " << fill_price << std::endl;
         } else if (order.type == Order::Type::LIMIT) {
             // Use OrderBook for limit order fills
             if (order_book_ != nullptr) {
@@ -434,11 +431,11 @@ void OrderManager::match_orders_for_symbol(const std::string& symbol, const Tick
                     fill_price = order.limit_price;
                 }
             }
-            std::cout << "DEBUG: Limit order fill_qty=" << fill_qty << " at " << fill_price << std::endl;
+            if (qse_debug_enabled()) std::cout << "DEBUG: Limit order fill_qty=" << fill_qty << " at " << fill_price << std::endl;
         }
         
         if (fill_qty > 0) {
-            std::cout << "DEBUG: Filling order with qty=" << fill_qty << " at price=" << fill_price << std::endl;
+            if (qse_debug_enabled()) std::cout << "DEBUG: Filling order with qty=" << fill_qty << " at price=" << fill_price << std::endl;
             fill_order(order, fill_qty, fill_price, tick, depth_fill);
 
             if (order.is_filled()) {
@@ -469,8 +466,8 @@ void OrderManager::fill_order(Order& order, Volume fill_qty, Price fill_price, c
             } else { // SELL
                 base_fill_price -= slippage;
             }
-            std::cout << "DEBUG: Applied slippage for " << order.symbol 
-                      << " - base: " << fill_price << ", slippage: " << slippage 
+            if (qse_debug_enabled()) std::cout << "DEBUG: Applied slippage for " << order.symbol
+                      << " - base: " << fill_price << ", slippage: " << slippage
                       << ", final: " << base_fill_price << std::endl;
         }
     }

--- a/src/strategy/SMACrossoverStrategy.cpp
+++ b/src/strategy/SMACrossoverStrategy.cpp
@@ -1,4 +1,5 @@
 #include "qse/strategy/SMACrossoverStrategy.h"
+#include "qse/core/Debug.h"
 #include <iostream>
 #include <fstream>
 
@@ -36,7 +37,7 @@ void SMACrossoverStrategy::on_bar(const qse::Bar& bar) {
     double current_short_val = short_ma_.get_value();
     double current_long_val = long_ma_.get_value();
 
-    std::cerr << "[SMACrossoverStrategy] " << symbol_ 
+    if (qse_debug_enabled()) std::cerr << "[SMACrossoverStrategy] " << symbol_
               << " | Close: " << bar.close
               << " | PrevShort: " << prev_short_val << " | PrevLong: " << prev_long_val
               << " | CurrShort: " << current_short_val << " | CurrLong: " << current_long_val << std::endl;

--- a/tests/cpp/test_Backtester.cpp
+++ b/tests/cpp/test_Backtester.cpp
@@ -225,7 +225,11 @@ TEST_F(BacktesterTickIntegrationTest, TickStreamIntegration) {
     // Expect attempt_fills to be called after each tick
     EXPECT_CALL(*mock_order_manager, attempt_fills())
         .Times(test_ticks_.size());
-    
+
+    // Expect the equity curve to be marked to market after each tick
+    EXPECT_CALL(*mock_order_manager, record_equity(_, _))
+        .Times(test_ticks_.size());
+
     // Expect strategy to receive bars when they're completed
     // The BarBuilder will create bars and call on_bar
     EXPECT_CALL(*mock_strategy, on_bar(_))
@@ -335,7 +339,9 @@ TEST_F(BacktesterTickIntegrationTest, TickProcessingOrder) {
         .Times(test_ticks_.size());
     EXPECT_CALL(*mock_order_manager, attempt_fills())
         .Times(test_ticks_.size());
-    
+    EXPECT_CALL(*mock_order_manager, record_equity(_, _))
+        .Times(test_ticks_.size());
+
     // Expect strategy to receive bars when they're completed
     EXPECT_CALL(*mock_strategy, on_bar(_))
         .Times(::testing::AtLeast(1));
@@ -388,7 +394,9 @@ TEST_F(BacktesterTickIntegrationTest, LargeTickStream) {
         .Times(1000);
     EXPECT_CALL(*mock_order_manager, attempt_fills())
         .Times(1000);
-    
+    EXPECT_CALL(*mock_order_manager, record_equity(_, _))
+        .Times(1000);
+
     // Expect strategy to receive bars when they're completed
     EXPECT_CALL(*mock_strategy, on_bar(_))
         .Times(::testing::AtLeast(1));

--- a/tests/python/test_tearsheet.py
+++ b/tests/python/test_tearsheet.py
@@ -1,0 +1,174 @@
+"""Unit tests for scripts/analysis/tearsheet.py (roadmap B3).
+
+Every expected value is hand-computed from the metric definition and asserted
+to 4 decimal places; fixtures are built so the arithmetic stays exact.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "analysis"))
+
+import tearsheet  # noqa: E402
+
+TOL = 1e-4
+
+
+def equity_from_returns(returns, start=100_000.0):
+    values = [start]
+    for r in returns:
+        values.append(values[-1] * (1.0 + r))
+    return pd.Series(values)
+
+
+class TestSharpe:
+    def test_known_value(self):
+        # returns [0.01, -0.005, 0.02]: mean = 0.025/3, std(ddof=1) of the
+        # deviations {1/600, -2/150, 7/600} -> sqrt(9.5/60000);
+        # sharpe = mean/std * sqrt(252) = 10.51314966...
+        returns = pd.Series([0.01, -0.005, 0.02])
+        assert tearsheet.annualized_sharpe(returns) == pytest.approx(10.5131, abs=TOL)
+
+    def test_zero_mean_is_zero(self):
+        # +1% then -1% alternating has mean ~ -0.005% but symmetric case:
+        # use exactly offsetting arithmetic returns -> mean 0, sharpe 0
+        returns = pd.Series([0.01, -0.01, 0.01, -0.01])
+        assert tearsheet.annualized_sharpe(returns) == pytest.approx(0.0, abs=TOL)
+
+    def test_constant_returns_guard(self):
+        # zero variance must not divide by zero
+        returns = pd.Series([0.01, 0.01, 0.01])
+        assert tearsheet.annualized_sharpe(returns) == 0.0
+
+
+class TestDrawdownAndCalmar:
+    def test_max_drawdown_exact(self):
+        # peak 120 -> trough 90: drawdown = (90-120)/120 = -0.25 exactly
+        equity = pd.Series([100.0, 120.0, 90.0, 100.0, 130.0])
+        assert tearsheet.max_drawdown(equity) == pytest.approx(-0.25, abs=TOL)
+
+    def test_monotonic_curve_has_no_drawdown(self):
+        equity = pd.Series([100.0, 101.0, 102.0, 103.0])
+        assert tearsheet.max_drawdown(equity) == pytest.approx(0.0, abs=TOL)
+
+    def test_calmar_exact(self):
+        # One 252-return year ending +20% with a single dip 110 -> 99:
+        # CAGR = 0.2, max drawdown = (99-110)/110 = -0.1, Calmar = 2.0
+        up = np.linspace(100.0, 110.0, 101)          # days 0..100
+        dip = np.array([99.0])                        # day 101
+        recover = np.linspace(99.0, 120.0, 151)       # days 102..252
+        equity = pd.Series(np.concatenate([up, dip, recover]))
+        assert len(equity) == 253  # 252 returns = exactly one year
+        assert tearsheet.cagr(equity) == pytest.approx(0.2, abs=TOL)
+        assert tearsheet.calmar_ratio(equity) == pytest.approx(2.0, abs=TOL)
+
+    def test_cagr_compounds_over_two_years(self):
+        # 504 returns = 2 years, total growth 1.21 -> CAGR = sqrt(1.21)-1 = 0.1
+        equity = pd.Series(np.linspace(0.0, 1.0, 505) ** 2 * 21_000.0 + 100_000.0)
+        assert equity.iloc[-1] / equity.iloc[0] == pytest.approx(1.21, abs=1e-12)
+        assert tearsheet.cagr(equity) == pytest.approx(0.1, abs=TOL)
+
+
+class TestTurnover:
+    def test_exact_turnover(self):
+        # Flat 100k equity for one year (253 points = 252 returns);
+        # notional = |100|*500 + |-100|*500 + |250|*400 = 200,000
+        # turnover = 200,000 / 100,000 / 1yr = 2.0
+        equity = pd.Series(np.full(253, 100_000.0))
+        trades = pd.DataFrame({
+            "quantity": [100, -100, 250],
+            "price": [500.0, 500.0, 400.0],
+        })
+        assert tearsheet.annualized_turnover(trades, equity) == pytest.approx(2.0, abs=TOL)
+
+    def test_no_trades_is_zero(self):
+        equity = pd.Series(np.full(253, 100_000.0))
+        trades = pd.DataFrame({"quantity": [], "price": []})
+        assert tearsheet.annualized_turnover(trades, equity) == 0.0
+
+
+class TestRollingSharpe:
+    def test_window_matches_full_sample_sharpe(self):
+        # The final rolling value over window w equals the plain Sharpe of the
+        # last w returns
+        rng = np.random.default_rng(7)
+        returns = pd.Series(rng.normal(0.0005, 0.01, 100))
+        rolling = tearsheet.rolling_sharpe(returns, window=63)
+        assert len(rolling) == len(returns)
+        assert rolling.iloc[:62].isna().all()
+        expected = tearsheet.annualized_sharpe(returns.iloc[-63:])
+        assert rolling.iloc[-1] == pytest.approx(expected, abs=TOL)
+
+
+class TestAlphaBeta:
+    def test_exact_linear_relationship(self):
+        # strategy = 0.001 + 0.5 * benchmark exactly ->
+        # beta = 0.5, alpha = 0.001 * 252 = 0.252
+        rng = np.random.default_rng(11)
+        bench = pd.Series(rng.normal(0.0, 0.01, 60))
+        strat = 0.001 + 0.5 * bench
+        alpha, beta = tearsheet.alpha_beta(strat, bench)
+        assert beta == pytest.approx(0.5, abs=TOL)
+        assert alpha == pytest.approx(0.252, abs=TOL)
+
+    def test_short_overlap_returns_nan(self):
+        alpha, beta = tearsheet.alpha_beta(pd.Series([0.01]), pd.Series([0.02]))
+        assert np.isnan(alpha) and np.isnan(beta)
+
+
+class TestLoaders:
+    def test_load_equity_current_format_ms_epoch(self, tmp_path):
+        path = tmp_path / "equity.csv"
+        path.write_text(
+            "timestamp,equity\n"
+            "1748318400000,100000\n"
+            "1748404800000,101000\n"
+        )
+        equity = tearsheet.load_equity(str(path))
+        assert isinstance(equity.index, pd.DatetimeIndex)
+        assert equity.iloc[-1] == pytest.approx(101000.0)
+
+    def test_load_equity_legacy_portfolio_value(self, tmp_path):
+        path = tmp_path / "equity.csv"
+        path.write_text(
+            "timestamp,portfolio_value\n"
+            "1700000000,100000\n"
+            "1700086400,100500\n"
+        )
+        equity = tearsheet.load_equity(str(path))
+        assert len(equity) == 2
+        assert equity.iloc[-1] == pytest.approx(100500.0)
+
+    def test_duplicate_timestamps_keep_last(self, tmp_path):
+        path = tmp_path / "equity.csv"
+        path.write_text(
+            "timestamp,equity\n"
+            "1700000000,100000\n"
+            "1700000000,100700\n"
+        )
+        equity = tearsheet.load_equity(str(path))
+        assert len(equity) == 1
+        assert equity.iloc[0] == pytest.approx(100700.0)
+
+
+class TestPdfGeneration:
+    def test_build_tearsheet_writes_pdf(self, tmp_path):
+        rng = np.random.default_rng(3)
+        returns = rng.normal(0.0004, 0.01, 300)
+        equity = equity_from_returns(returns)
+        equity.index = pd.bdate_range("2024-01-02", periods=len(equity))
+        bench = equity_from_returns(rng.normal(0.0003, 0.008, 300))
+        bench.index = pd.bdate_range("2024-01-02", periods=len(bench))
+        trades = pd.DataFrame({"quantity": [10, -10], "price": [100.0, 101.0]})
+
+        out = tmp_path / "tearsheet.pdf"
+        summary = tearsheet.build_tearsheet(equity, trades, bench, str(out), "test")
+
+        assert out.exists() and out.stat().st_size > 10_000
+        assert out.read_bytes()[:5] == b"%PDF-"
+        for key in ("Sharpe (ann.)", "Calmar", "Turnover (ann.)", "Alpha (ann.)", "Beta"):
+            assert key in summary


### PR DESCRIPTION
## What

Adds the institutional tearsheet (B3 in docs/TASK_BREAKDOWN.md) and fixes three engine bugs it exposed.

**Tearsheet** (`scripts/analysis/tearsheet.py`):
- Metrics as pure, unit-tested functions: annualized Sharpe, max drawdown, CAGR, Calmar, annualized turnover, rolling Sharpe, and alpha/beta OLS regression vs a benchmark
- 3-page PDF report via matplotlib PdfPages: equity + drawdown + metrics table, rolling Sharpe + return distribution, benchmark-relative growth + return regression
- Tolerant loaders: current (`timestamp,equity`) and legacy (`portfolio_value`) formats, epoch timestamps at any resolution (s/ms/us/ns), intraday curves resampled to daily
- 16 pytest cases in `tests/python/test_tearsheet.py` assert hand-computed expected values to 4 decimal places (fixtures constructed for exact arithmetic, e.g. Calmar = 2.0, turnover = 2.0, beta = 0.5)

**Engine fixes** (found by running the tearsheet on a real backtest):
- `Backtester::run` never called `record_equity`, so every equity CSV the engine ever wrote was header-only; the portfolio is now marked to market once per tick with a last-seen price map
- Three static failbit hacks (OrderManager, BarBuilder, TickPublisher) set `std::cout` to a failed state at load time, silencing stdout in **every** binary linking qse; replaced with opt-in debug tracing via `QSE_DEBUG=1` (new `include/qse/core/Debug.h`), with hot-path logs gated so the original performance concern stays addressed
- `strategy_engine` passed no symbol to `CSVDataReader`, so legacy-format ticks were tagged `UNKNOWN` and the SMA strategy (registered for `AAPL`) never traded

## Why

B3 turns raw engine output into thesis-grade results pages, and it is the reporting layer for the upcoming fixed-slippage vs microstructure-realism experiments. The engine fixes matter beyond the tearsheet: equity output and stdout were both silently broken for every consumer.

## Reviewer notes

- `StrictMock` Backtester tests gained an explicit `record_equity` expectation (three tests in `tests/cpp/test_Backtester.cpp`)
- Turnover definition: single-counted traded notional / mean equity / years, documented in the function
- Demo verified end to end: SMA 20/50 on AAPL ticks -> 19,184 equity points, 456 trades, `results/tearsheet.pdf` (3 pages, valid PDF)
- 207/207 ctest, 16/16 pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
