### PR TITLE
docs: low-latency + A/B audit tracks and complete phase narrative

### DIFF
--- a/docs/PROJECT_PHASES.md
+++ b/docs/PROJECT_PHASES.md
@@ -1,0 +1,347 @@
+# QSE — Complete Phase Breakdown
+
+*The Quantitative Strategy Engine: from Python-grade backtester to an
+institutional-grade C++ trading system.*
+
+This is the narrative companion to [TASK_BREAKDOWN.md](TASK_BREAKDOWN.md). The
+breakdown is the execution checklist (chunks with pass/fail criteria); this
+document explains **what each phase is, why it exists, how it was or will be
+built, and what it proves** — including the phases that are already complete.
+
+**Thesis research question:** *How much does market-microstructure realism —
+a full-depth limit order book, VWAP fills, and queue position — change the
+measured performance of trading strategies versus the fixed-slippage
+assumptions of standard backtesters?*
+
+---
+
+## System at a glance
+
+```
+                       ┌────────────────────────────────────────────┐
+  data/*.csv ─────────►│ CSVDataReader / ParquetDataReader          │
+  (bars & ticks)       └──────────────┬─────────────────────────────┘
+                                      │ ticks
+  ZeroMQ + protobuf ──► TickSubscriber┤
+  (distributed mode)                  ▼
+                       ┌────────────────────────────────────────────┐
+                       │ Backtester ── BarBuilder ── BarRouter      │
+                       │  (tick loop, per-symbol bars, mark-to-mkt) │
+                       └──────┬─────────────────────────┬───────────┘
+                              │ bars/ticks              │ orders
+                       ┌──────▼──────────┐    ┌─────────▼───────────┐
+                       │ IStrategy       │    │ OrderManager        │
+                       │  SMA crossover  │    │  naive fills  ──or──│
+                       │  Pairs trading  │    │  OrderBookFullDepth │
+                       │  Factor / multi │    │  (FIFO queues, VWAP │
+                       └─────────────────┘    │   walk, queue pos)  │
+                                              └─────────┬───────────┘
+                                                        │ equity/tradelog CSVs
+                       ┌────────────────────────────────▼───────────┐
+                       │ Python analysis: tearsheet.py,             │
+                       │ impact_study.py, (slippage_audit.py)       │
+                       └────────────────────────────────────────────┘
+```
+
+**Current scale:** ~19k ticks replayed in 24 ms (~800k ticks/s) on Apple
+Silicon; 207 C++ tests + 16 Python tests; CI green on every push
+(ubuntu-latest, GCC 13 + Arrow 24 at C++20, cross-checked against local
+Apple clang at C++17).
+
+---
+
+## Phase 1 — Foundational Realism ✅
+
+**Goal:** make the simplest backtest honest.
+
+- **Transaction costs.** `OrderManager` applies per-trade commission and a
+  slippage adjustment to every fill, so PnL is net of costs from day one. A
+  naive SMA run on SPY loses ~$490 on $100k — a realistic outcome that a
+  cost-free backtester would report as profit.
+- **O(1) indicators.** The SMA crossover strategy uses rolling
+  `MovingAverage` / `MovingStandardDeviation` accumulators (constant-time
+  update per bar) instead of recomputing windows — the difference between
+  O(n·w) and O(n) over a full backtest.
+- **Auditable output.** Every run writes `equity_*.csv` (mark-to-market curve)
+  and `tradelog_*.csv` (every fill with price, quantity, cash), which the
+  entire Python analysis layer consumes.
+
+**Proves:** understanding that backtest PnL without costs is fiction.
+
+## Phase 2 — Performance Engineering ✅
+
+**Goal:** measure before optimizing; keep receipts.
+
+- Profiled the engine with **Instruments** to find real bottlenecks rather
+  than guessing.
+- Eliminated per-bar copies, pre-allocated vectors, and tightened the SMA
+  hot path. Historical benchmark: the 6,444-bar SPY backtest ran in
+  **~3.8 ms** after optimization.
+- Before/after evidence lives in `docs/benchmarks/01–03_*.png`.
+
+**Proves:** disciplined performance work — profile, change one thing, measure.
+
+## Phase 3 — Advanced Architecture ✅
+
+**Goal:** the three structural jumps that separate a script from a system.
+
+- **3.1 Multi-asset parallelism.** A hand-rolled C++ `ThreadPool` runs
+  independent per-symbol backtests concurrently (`multi_symbol_engine`,
+  `multi_strategy_engine`).
+- **3.2 Tick-driven core.** The `Backtester` consumes raw ticks;
+  `BarBuilder` aggregates them into time bars on the fly and `BarRouter`
+  dispatches per-symbol bars, so bar-driven strategies (SMA, pairs) run
+  unchanged on tick data. Handles out-of-order ticks, bar boundaries, and
+  end-of-stream flush — all unit-tested.
+- **3.3 Distributed mode.** `data_publisher` and `strategy_engine` are
+  separate executables connected by **ZeroMQ** pub/sub with **protobuf**
+  serialization (`TickPublisher` / `TickSubscriber` / `ZeroMQDataReader`) —
+  the standard shape of production market-data infrastructure.
+
+**Proves:** concurrency, event-driven design, and distributed-systems layout.
+
+## Phase 4 — Quantitative Modeling ✅ (far beyond original spec)
+
+**Goal:** breadth beyond trend-following; the original plan asked for a
+"simple factor model" — what exists is a full cross-sectional research stack.
+
+- **4.1 Statistical arbitrage.** `PairsTradingStrategy`: spread z-score entry
+  and exit with rolling hedge ratio; pair discovery and diagnostics in
+  `scripts/analysis/find_pairs.py` and friends.
+- **4.2 Multi-factor pipeline.** The chain runs
+  `UniverseFilter → MultiFactorCalculator → CrossSectionalRegression
+  (robust variants tested) → ICMonitor (information-coefficient tracking,
+  distribution-tested) → AlphaBlender (IC-weighted signal blending with
+  weight-sum property tests) → RiskModel (multi-asset beta/covariance) →
+  PortfolioBuilder`. Factor data flows through **Apache Arrow/Parquet**
+  tables; configuration is YAML; `compute_factors` is the standalone tool.
+- **4.3 Portfolio optimization.** `PortfolioBuilder` is a constrained
+  **quadratic-programming optimizer**: maximizes blended alpha subject to
+  gross/net exposure caps and beta neutrality, with projection back to the
+  feasible set. `FactorStrategy` + `FactorExecutionEngine` turn target
+  weights into delta orders behind a rebalance guard (no churn below
+  threshold), from `WeightsLoader`-provided daily weight files.
+
+**Proves:** the vocabulary and mechanics of modern quant research — factors,
+IC, blending, risk models, constrained portfolio construction.
+
+## Phase 5 — Market Microstructure ✅ (the thesis core)
+
+**Goal:** replace "fills happen at the price you asked" with a real market.
+
+- **5.1 Full-depth order book.** `OrderBookFullDepth`: price-ordered levels
+  (bids descending, asks ascending), each level a **FIFO queue** of orders
+  with per-order sizes, O(1) queue-position lookup via position maps, and
+  stable queue IDs for cancellation.
+- **5.2 Impact-priced market orders (A2).** Market orders **walk the book**:
+  consume the best level, then the next, paying the volume-weighted average —
+  so a 10,000-share order pays measurably more per share than a 100-share
+  order against the same book. Selected per run by the `fill_model` config
+  flag (`naive` vs `full_depth`), keeping the A/B comparison one config edit
+  apart.
+- **5.3 Queue-position-aware limit fills (A3).** Passive orders join the
+  **back** of the queue at their price. Trade prints consume the queue
+  FIFO — an order fills only after the displayed size ahead of it is
+  exhausted. Marketable limits take liquidity up to their limit price and
+  rest the remainder. Cancels remove orders from the queue. Displayed quote
+  size re-enters at the **front** of its level on refresh (the conservative
+  queue assumption forced by L1 data — the real queue is invisible). Maker
+  fills are attributed even when one strategy order trades against another.
+- **5.4 Empirical impact study (A4).** `impact_sweep` + `impact_study.py`
+  sweep order sizes 50→51,200 through the book against real AAPL tick prices
+  under two synthetic depth profiles and fit the impact law
+  `slippage = a·Q^b`:
+
+  | Depth profile | Fitted b | Theory | R² |
+  |---|---|---|---|
+  | uniform (equal size/level) | **1.017** | 1.0 | 0.9999 |
+  | linear (deepening book)    | **0.569** | 0.5 (square-root law) | 0.9989 |
+
+  The exponent *emerges* from liquidity distribution — the linear cost model
+  every naive backtester assumes is exactly the uniform-depth special case,
+  and real markets (square-root law) are not that case.
+
+**Proves:** microstructure literacy — priority rules, adverse selection,
+market impact — implemented, not just cited.
+
+## Phase 6 — Data Quality & Analysis 🟡
+
+**Goal:** institutional-grade inputs and outputs.
+
+- **6.1 Tearsheet ✅ (B3).** `scripts/analysis/tearsheet.py`: annualized
+  Sharpe, max drawdown, CAGR, Calmar, annualized turnover, rolling Sharpe,
+  and alpha/beta OLS vs a benchmark, rendered to a 3-page PDF. All metrics
+  are pure functions with 16 pytest cases asserting hand-computed values to
+  4 decimals. Building it exposed and fixed three real engine bugs: equity
+  curves were never recorded, three failbit hacks silenced stdout in every
+  qse binary (now opt-in `QSE_DEBUG=1` via `qse/core/Debug.h`), and the
+  strategy engine never tagged ticks with a symbol.
+- **6.2 Missing-data handling ⏳ (B1).** Forward-fill with gap reporting in
+  the Python pipeline; C++ readers surface gap counts instead of silently
+  mis-parsing.
+- **6.3 Corporate actions ⏳ (B2).** Split/dividend back-adjustment from an
+  actions file, verified against a known event (AAPL 4:1, 2020-08-31): prices
+  ÷4, volumes ×4, and a buy-and-hold equity curve that does **not** jump
+  across the split date.
+
+**Proves:** results you can hand to a PM, from inputs you can trust.
+
+## Phase 7 — DevOps & Reproducibility 🟡
+
+**Goal:** engineering hygiene that survives other people's machines.
+
+- **7.1 CI ✅ (C1).** GitHub Actions on every push/PR: Ubuntu runner installs
+  Arrow/Parquet from the official apt repo plus protobuf/ZeroMQ/yaml-cpp,
+  checks out the Eigen submodule, builds Release, runs the full ctest suite
+  (~2.5 min). Because Arrow 24 forces C++20 on GCC while local builds are
+  C++17 Apple clang, **every push is cross-checked against two compilers and
+  two language standards** — this caught five classes of portability bugs on
+  day one.
+- **7.2 Repo hygiene ✅ (C4).** Untracked stale binaries and ctest logs;
+  `git status` stays clean through a full build + test cycle.
+- **7.3 Formatting ⏳ (C2).** `.clang-format` + `black`/`flake8`, enforced in CI.
+- **7.4 Static analysis ⏳ (C3).** `clang-tidy` (bugprone/performance/modernize)
+  as a CI gate.
+- **7.5 Docker ⏳ (D1).** Multi-stage `Dockerfile` (ubuntu:24.04 build stage →
+  slim runtime): `docker build -t qse . && docker run qse` reproduces a
+  backtest on any machine with only Docker installed — the "it just works"
+  distribution standard.
+
+**Proves:** the difference between code that works here and software that
+works anywhere.
+
+## Phase 8 — Low-Latency Engineering ⏳ (new, Track G)
+
+**Goal:** hardware-sympathy — the layer trading firms actually interview on.
+
+### 8.1 Custom memory management: the arena allocator (G1)
+
+*The problem.* Every `new`/`malloc` walks OS heap structures in unpredictable
+time — 10 ns on a good day, thousands when it triggers a page fault or
+context switch. In trading, **jitter** (variance, not mean) is what loses the
+trade; per-order heap allocation in the fill path is a fatal flaw.
+
+*The build.* `qse::Arena` — a bump allocator: one large contiguous block
+requested up front; each allocation returns the current offset and bumps it
+by the object size (two instructions, perfectly predictable); **no individual
+deallocation ever** — the whole arena resets in one operation when the
+session ends. Implemented as a custom allocator or C++17
+`std::pmr::monotonic_buffer_resource` with instrumentation, then plugged into
+`OrderBookFullDepth`'s level containers via `std::pmr`.
+
+*The payoff.* Beyond eliminating jitter, all live orders pack **sequentially
+in one block**, so the CPU prefetcher streams them through L1/L2 cache during
+book walks. Deliverable is a benchmark artifact
+(`docs/benchmarks/04_arena_allocator.md`): ≥1M allocations arena-vs-heap plus
+before/after full-depth fill numbers.
+
+### 8.2 Lock-free multi-threading: the SPSC ring buffer (G2)
+
+*The problem.* Live mode needs a network thread (feeding ticks) and a
+strategy thread (trading on them). Guard the hand-off with a `std::mutex` and
+the network thread blocks whenever the strategy holds the lock — a frozen
+feed during the exact moments the market is moving.
+
+*The build.* `qse::SPSCRingBuffer<T>` — a fixed power-of-two array that wraps
+around; the producer owns an atomic `write_index`, the consumer owns an
+atomic `read_index`; neither ever locks. Two hardware details carry the
+design:
+  - **False sharing.** CPUs move memory in 64-byte cache lines. If the two
+    indices share a line, each core's write invalidates the other core's L1
+    copy on every operation — a silent, catastrophic slowdown. `alignas(64)`
+    forces the indices onto separate lines.
+  - **Memory ordering.** The hand-off uses acquire/release semantics
+    (`std::memory_order_acquire`/`release`) so the consumer never observes an
+    index advance before the payload write, while each side reads its own
+    index relaxed.
+
+*The payoff.* Verified by a ≥10M-item two-thread stress test with checksum,
+run clean under ThreadSanitizer, plus a throughput benchmark vs a mutexed
+queue (`docs/benchmarks/05_spsc_ring_buffer.md`). This structure is the
+prerequisite for Phase 10's live feed.
+
+**Proves:** cache lines, atomics, and allocation behavior — the exact
+territory of a C++ trading-systems interview.
+
+## Phase 9 — The Business Proof: A/B Slippage Audit ⏳ (new, Track H)
+
+**Goal:** convert all the infrastructure above into one financial number.
+
+*The problem.* Standard backtesters assume infinite liquidity: "buy 5,000
+shares" fills instantly at the close. In reality the order eats through the
+book, pays VWAP degradation, and may wipe out the strategy's edge. The profit
+difference between those two worlds is invisible — until you measure it.
+
+*The build (H1).* Run the **exact same strategy on the exact same data**
+through two engine configurations that already exist behind the `fill_model`
+flag:
+  - **Engine A (naive):** instant fills, fixed slippage — the
+    infinite-liquidity assumption every tutorial backtester makes.
+  - **Engine B (institutional):** the Phase 5 book — market orders walk
+    levels and pay true VWAP, limit orders wait their turn in the FIFO queue.
+
+Repeat across order-size regimes (1×, 10×, 50×). `slippage_audit.py` overlays
+the paired equity curves; the gap between them is the **phantom profit** —
+the dollar amount the naive backtest hallucinated. The report (built on the
+Phase 6 tearsheet machinery) states it as the headline: *"the naive backtest
+overstates this strategy's Sharpe by X% at size Y because it ignores queue
+position and depth."*
+
+**Proves:** the intersection the whole project aims at — quantitative
+research claims, validated or destroyed by systems engineering. This is the
+artifact to hand across the interview table, and the results chapter of the
+thesis.
+
+## Phase 10 — Live Trading Integration ⏳ (Track E)
+
+**Goal:** demonstrate the engine is an execution system, not just a simulator.
+
+- **10.1 `IExecutionHandler` (E1).** Order submission/cancel/fill-notification
+  behind an interface; the backtest fill logic becomes
+  `SimulatedExecutionHandler`, strategies depend only on the abstraction.
+- **10.2 Alpaca paper trading (E2).** `AlpacaExecutionHandler` speaks REST to
+  the free Alpaca paper API (keys from `.env`, never committed); unit tests
+  run against a mocked HTTP layer so CI needs no network.
+- **10.3 Live mode (E3).** `--mode live`: Alpaca market-data websocket →
+  **SPSC ring buffer (Phase 8)** → the existing `BarBuilder`/strategy
+  pipeline → `AlpacaExecutionHandler`. The tick-driven architecture from
+  Phase 3 means the strategy code does not change between backtest and live —
+  which is the entire point of event-driven design.
+
+**Proves:** full-stack capability — the same code path from historical CSV to
+a live brokerage session.
+
+## Phase 11 — Presentation & Thesis ⏳ (Track F)
+
+**Goal:** make the work legible to recruiters, professors, and hiring managers.
+
+- **11.1 Whitepaper README (F1).** Architecture diagram, headline benchmarks,
+  tearsheet and audit figures, quickstart that works from a fresh clone.
+- **11.2 Notebook walkthrough (F2).** Jupyter demo: run the C++ engine,
+  load results, render the tearsheet inline — executes clean via
+  `nbconvert --execute`.
+- **11.3 One-pager (F3).** Single PDF: architecture, key results, repo link.
+- **11.4 Thesis write-up (F4).** 25–40 pages in `docs/thesis/`: introduction,
+  related work (impact laws, queue models), system architecture (Phases 1–8),
+  methodology (Phases 5, 9), results (impact exponents, phantom profit,
+  Sharpe inflation), limitations (L1-reconstructed depth, no self-trade
+  prevention, synthetic queue assumptions), future work.
+
+**Proves:** communication — the skill that makes the other ten phases count.
+
+---
+
+## Results ledger (updated as phases land)
+
+| Evidence | Value | Where |
+|---|---|---|
+| Tick replay throughput | ~800k ticks/s (19,184 ticks / 24 ms) | strategy_engine |
+| Historical bar-backtest benchmark | ~3.8 ms / 6,444 bars | docs/benchmarks |
+| Impact exponent, uniform depth | b = 1.017 (theory 1.0), R² 0.9999 | docs/research/microstructure |
+| Impact exponent, linear depth | b = 0.569 (theory 0.5), R² 0.9989 | docs/research/microstructure |
+| C++ tests | 207 (ctest, mac + Linux CI) | tests/cpp |
+| Python tests | 16 (pytest, hand-computed metrics) | tests/python |
+| CI wall time | ~2.5 min per push | GitHub Actions |
+| Phantom profit / Sharpe inflation | *pending H1* | — |
+| Arena vs heap allocation | *pending G1* | — |
+| SPSC vs mutex throughput | *pending G2* | — |

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -1,9 +1,12 @@
 # QSE Task Breakdown — Roadmap to a Thesis-Grade System
 
 Each chunk is independently completable and has an explicit **Done when** test. Work top to
-bottom within a track; tracks are mostly independent of each other.
+bottom within a track; tracks are mostly independent of each other. The narrative companion
+to this checklist — full phase descriptions including completed work — is
+[PROJECT_PHASES.md](PROJECT_PHASES.md).
 
-**Recommended order:** A1 → C1 → C4 → A2 → B3 → A3 → A4 → B1 → B2 → D1 → C2 → C3 → E1 → E2 → E3 → F1 → F2 → F3 → F4
+**Remaining work, recommended order:** H1 → B1 → B2 → D1 → C2 → C3 → G1 → G2 → E1 → E2 → E3 → F1 → F2 → F3 → F4 (A5 optional)
+**Completed so far:** A1 → C1 → C4 → A2 → A3 → A4 → B3
 
 ---
 
@@ -21,6 +24,8 @@ bottom within a track; tracks are mostly independent of each other.
 | 7 Live trading | ❌ Not started |
 | 8 Presentation | ❌ Not started |
 | Docker | ❌ No Dockerfile |
+| G Low-latency engineering (arena, SPSC) | ❌ New track (added 2026-07-05) — not started |
+| H A/B slippage audit | ❌ New track (added 2026-07-05) — unblocked: needs only A2+A3+B3, all done |
 
 ---
 
@@ -161,6 +166,72 @@ bottom within a track; tracks are mostly independent of each other.
   the resulting Alpaca paper fills reconcile with the local trade log.
 
 ---
+
+## Track G — Low-Latency Engineering 🎓
+
+*Hardware-level engineering: heap jitter, cache locality, false sharing, atomic
+memory ordering. Each chunk produces a committed benchmark artifact, not just code.*
+
+### G1. Arena (bump) allocator for the hot path
+- Implement `qse::Arena`: one large contiguous block requested up front, a
+  single offset pointer "bumped" per allocation, **no per-object deallocation**
+  — the whole arena resets in one operation at end of session/backtest. Either
+  a custom bump allocator or `std::pmr::monotonic_buffer_resource` wrapped
+  with instrumentation (bytes used, high-water mark, allocation count).
+- Adopt in the hot path: back `OrderBookFullDepth`'s per-level containers with
+  `std::pmr` equivalents so resting orders pack contiguously — the point is
+  L1/L2 cache locality, and the fill benchmark must show it.
+- Files: new `include/qse/core/Arena.h`, `OrderBookFullDepth.h/.cpp`,
+  new `tests/cpp/ArenaTest.cpp`, microbenchmark tool in `src/tools/`
+- **Done when:** gtest covers alignment guarantees, bump arithmetic,
+  exhaustion policy, and reset semantics; an allocation microbenchmark (≥1M
+  allocations, arena vs `new`/`delete`) plus a before/after full-depth fill
+  benchmark are committed to `docs/benchmarks/04_arena_allocator.md`; full
+  suite still green on mac and CI.
+
+### G2. SPSC lock-free ring buffer
+- Implement `qse::SPSCRingBuffer<T>`: fixed power-of-two capacity; the
+  producer owns an atomic `write_index`, the consumer owns an atomic
+  `read_index`; **`alignas(64)` on each index** so the two cores never share a
+  cache line (false sharing kills exactly this structure); acquire/release
+  ordering on the hand-off, relaxed loads on the owner's own index.
+- Integrate: the ZeroMQ subscriber (network thread, producer) hands ticks to
+  the strategy thread (consumer) through the ring instead of any locked
+  structure — this is the prerequisite for live mode (E3), where a blocked
+  network thread means dropped market data.
+- Files: new `include/qse/core/SPSCRingBuffer.h`, the subscriber/live-feed
+  path, new `tests/cpp/SPSCRingBufferTest.cpp`
+- **Done when:** unit tests cover empty/full/wraparound/ordering; a two-thread
+  stress test moves ≥10M items with a checksum match and runs clean under
+  ThreadSanitizer (`-fsanitize=thread`); a throughput benchmark vs a
+  `std::mutex`+`std::queue` baseline is committed to
+  `docs/benchmarks/05_spsc_ring_buffer.md`.
+
+## Track H — The Business Proof: A/B Slippage Audit 🎓
+
+*The thesis experiment operationalized: identical strategy and data through two
+fill models; the gap between the equity curves is the "phantom profit" a naive
+backtester hallucinates.*
+
+### H1. A/B slippage audit
+- **Engine A (naive):** instant fills at close/mid with fixed slippage —
+  infinite-liquidity assumption. **Engine B (institutional):** the full-depth
+  book — market orders walk levels and pay VWAP (A2), limit orders join the
+  back of the FIFO queue and wait (A3). Both already exist behind the
+  `fill_model` config flag; this chunk builds the paired harness and audit.
+- Harness runs the same strategy + data through both configurations at several
+  order-size regimes (e.g. 1×, 10×, 50× base size), writing paired equity
+  curves and tradelogs. `scripts/analysis/slippage_audit.py` overlays the
+  curves, computes **phantom profit** ($ and % of naive PnL), naive-vs-real
+  Sharpe inflation, and a per-trade slippage distribution, and emits a PDF
+  through the tearsheet machinery (B3).
+- Files: new `src/tools/ab_audit.cpp`, new `scripts/analysis/slippage_audit.py`,
+  artifacts to `docs/research/microstructure/`
+- **Done when:** `python scripts/analysis/slippage_audit.py` produces
+  `slippage_audit.pdf` + `ab_audit_summary.md` reporting phantom profit and
+  Sharpe inflation per order-size regime, reproducible run-to-run; the
+  headline number ("naive backtest overstates Sharpe by X% at size Y") is
+  stated in the summary.
 
 ## Track F — Presentation & Thesis (Phase 8)
 


### PR DESCRIPTION
## What

Documentation only - two additions to the project roadmap:

**`docs/TASK_BREAKDOWN.md`** gains two new tracks with explicit done-when criteria:
- **Track G - Low-Latency Engineering:** G1 arena (bump) allocator (custom or `std::pmr::monotonic_buffer_resource`, adopted into the order book's containers for cache locality), G2 SPSC lock-free ring buffer (`alignas(64)` indices against false sharing, acquire/release ordering, ThreadSanitizer-verified stress test). Each chunk's deliverable includes a committed benchmark artifact in `docs/benchmarks/`.
- **Track H - The Business Proof:** H1 A/B slippage audit - identical strategy and data through the naive fill model vs the full-depth book (both already exist behind the `fill_model` flag from A2/A3), with a Python audit reporting the "phantom profit" and Sharpe inflation per order-size regime. Unblocked today; moved to the front of the recommended order.

**`docs/PROJECT_PHASES.md`** (new) is the narrative companion to the checklist: all eleven phases in detail, including completed work with evidence (factor-stack pipeline, impact exponents b=1.017/0.569, tearsheet + the three engine bugs it exposed, dual-compiler CI) and pending work with design rationale (heap jitter, cache-line invalidation, memory ordering, phantom profit). Opens with an architecture diagram and the thesis research question; closes with a results ledger that fills in as tracks land.

## Why

The three new features (arena allocator, SPSC ring buffer, A/B audit) strengthen the project's signal for quant-dev roles: hardware-level C++ plus a business-legible proof artifact. The phases document gives recruiters/advisors a single readable narrative separate from the execution checklist.

## Reviewer notes

- No code changes; nothing to run. CI will pass trivially.
- G2 (SPSC) is deliberately sequenced before live mode (E3) - the ring buffer is the network-thread -> strategy-thread hand-off live mode needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
