### PR TITLE
feat(data): missing-data handling with repair reporting (B1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ add_executable(run_tests
     tests/cpp/RebalanceGuardTest.cpp
     tests/cpp/FactorIntegrationTest.cpp
     tests/cpp/ConfigParseTest.cpp
+    tests/cpp/DataGapsTest.cpp
     tests/cpp/PriceLevelTest.cpp
     tests/cpp/QueuePositionTest.cpp
     tests/cpp/ImpactTest.cpp

--- a/docs/PROJECT_PHASES.md
+++ b/docs/PROJECT_PHASES.md
@@ -176,9 +176,11 @@ market impact — implemented, not just cited.
   curves were never recorded, three failbit hacks silenced stdout in every
   qse binary (now opt-in `QSE_DEBUG=1` via `qse/core/Debug.h`), and the
   strategy engine never tagged ticks with a symbol.
-- **6.2 Missing-data handling ⏳ (B1).** Forward-fill with gap reporting in
-  the Python pipeline; C++ readers surface gap counts instead of silently
-  mis-parsing.
+- **6.2 Missing-data handling ✅ (B1).** `forward_fill_ticks` in the Python
+  pipeline forward-fills prices, zeroes missing volumes, and reports every
+  repair instead of silently dropping rows; `CSVDataReader` counts
+  unparseable rows (one bad row no longer aborts a load) and surfaces
+  time-grid holes via `gap_count()`, with a data-quality warning at load.
 - **6.3 Corporate actions ⏳ (B2).** Split/dividend back-adjustment from an
   actions file, verified against a known event (AAPL 4:1, 2020-08-31): prices
   ÷4, volumes ×4, and a buy-and-hold equity curve that does **not** jump

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -5,8 +5,8 @@ bottom within a track; tracks are mostly independent of each other. The narrativ
 to this checklist — full phase descriptions including completed work — is
 [PROJECT_PHASES.md](PROJECT_PHASES.md).
 
-**Remaining work, recommended order:** B1 → B2 → D1 → C2 → C3 → G1 → G2 → E1 → E2 → E3 → F1 → F2 → F3 → F4 (A5 optional)
-**Completed so far:** A1 → C1 → C4 → A2 → A3 → A4 → B3 → H1
+**Remaining work, recommended order:** B2 → D1 → C2 → C3 → G1 → G2 → E1 → E2 → E3 → F1 → F2 → F3 → F4 (A5 optional)
+**Completed so far:** A1 → C1 → C4 → A2 → A3 → A4 → B3 → H1 → B1
 
 ---
 
@@ -19,7 +19,7 @@ to this checklist — full phase descriptions including completed work — is
 | 4.2 Factor model | ✅ Done **far beyond spec**: MultiFactorCalculator, UniverseFilter, CrossSectionalRegression, ICMonitor, AlphaBlender, RiskModel, PortfolioBuilder (QP), FactorExecutionEngine, rebalance guard, YAML config |
 | 4.3 Portfolio optimizer | ✅ Mostly done (constrained QP exists); mean-variance extension optional (A5) |
 | **OrderBookFullDepth** | ✅ Committed 2026-07-04: all 38 tests pass (PriceLevel, QueuePosition, Impact) |
-| 5 Data & tearsheet | 🟡 B3 tearsheet done 2026-07-05; B1 (ffill) and B2 (corporate actions) remain |
+| 5 Data & tearsheet | 🟡 B3 tearsheet + B1 missing-data done 2026-07-05; B2 (corporate actions) remains |
 | 6 CI / format / lint | 🟡 CI green as of 2026-07-04 (C1+C4 done); formatting (C2) and clang-tidy (C3) remain |
 | 7 Live trading | ❌ Not started |
 | 8 Presentation | ❌ Not started |
@@ -76,12 +76,14 @@ to this checklist — full phase descriptions including completed work — is
 
 ## Track B — Data Quality & Analysis (Phase 5)
 
-### B1. Missing-data handling (forward-fill)
-- Python: `process_data.py` gains ffill + gap report. C++: `CSVDataReader` /
-  `ParquetDataReader` tolerate and flag missing bars instead of silently
-  misbehaving.
-- **Done when:** pytest on a synthetic gappy CSV verifies filled values, and a
-  gtest confirms the reader surfaces the gap count.
+### B1. ✅ Missing-data handling (done 2026-07-05)
+- Python: `forward_fill_ticks` in `process_data.py` — ffill prices, zero
+  missing volumes, drop unfillable leading rows, report every repair
+  (7 pytest cases). C++: `CSVDataReader` counts unparseable rows instead of
+  crashing and surfaces time-grid holes via `gap_count()` (median-spacing
+  inference; 4 gtest cases); a data-quality warning prints on load.
+- ParquetDataReader left as-is (Arrow handles nulls upstream) — revisit if it
+  becomes a primary ingest path.
 
 ### B2. Corporate actions handler
 - `CorporateActionsHandler` (C++ or Python — pick one layer, don't do both)

--- a/include/qse/data/CSVDataReader.h
+++ b/include/qse/data/CSVDataReader.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "qse/data/IDataReader.h"
+#include <cstddef>
 #include <vector>
 #include <string>
 #include "qse/data/Data.h"
@@ -10,21 +11,34 @@ class CSVDataReader : public qse::IDataReader {
 public:
     explicit CSVDataReader(const std::string& file_path);
     CSVDataReader(const std::string& file_path, const std::string& symbol_override);
-    
+
     // Implement the new tick reading method.
     const std::vector<Tick>& read_all_ticks() const override;
-    
+
     // We still need to implement the bar reading method from the interface.
     const std::vector<Bar>& read_all_bars() const override;
+
+    // --- Data-quality report (populated during load) ---
+
+    // Rows that could not be parsed (missing/non-numeric fields) and were
+    // skipped instead of aborting the whole load
+    std::size_t skipped_row_count() const { return skipped_rows_; }
+
+    // Missing rows in the time grid, inferred from the median spacing of the
+    // loaded series (exact for grid data; heuristic for event-time ticks)
+    std::size_t gap_count() const { return gap_count_; }
 
 private:
     void load_data(); // Renamed to be more generic
     std::string file_path_;
     std::string symbol_override_;
-    
+
     // The reader now stores both ticks and bars.
     std::vector<Bar> bars_;
-    std::vector<Tick> ticks_; 
+    std::vector<Tick> ticks_;
+
+    std::size_t skipped_rows_ = 0;
+    std::size_t gap_count_ = 0;
 };
 
 } // namespace qse

--- a/scripts/data/process_data.py
+++ b/scripts/data/process_data.py
@@ -6,6 +6,55 @@ from pathlib import Path
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+
+def forward_fill_ticks(df: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
+    """Clean a tick DataFrame (price/volume, timestamp index) without
+    silently discarding data.
+
+    Missing prices are forward-filled from the last valid observation and
+    missing volumes become 0 (a filled row represents "no trade printed", not
+    a trade of unknown size). Rows before the first valid price cannot be
+    filled and are dropped. Returns (clean_df, report) where the report
+    counts every repair so gaps are surfaced instead of hidden:
+
+        prices_filled, volumes_filled, leading_rows_dropped, grid_gaps
+
+    grid_gaps counts missing rows in the timestamp grid, inferred from the
+    median spacing (exact for grid data, heuristic for event-time ticks).
+    """
+    df = df.copy()
+    for col in ("price", "volume"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    df.sort_index(inplace=True)
+
+    # Rows before the first valid price have nothing to fill from
+    valid_started = df["price"].notna().cummax()
+    leading_dropped = int((~valid_started).sum())
+    df = df[valid_started]
+
+    prices_filled = int(df["price"].isna().sum())
+    volumes_filled = int(df["volume"].isna().sum())
+    df["price"] = df["price"].ffill()
+    df["volume"] = df["volume"].fillna(0)
+
+    grid_gaps = 0
+    deltas = pd.Series(df.index).diff().dropna()
+    deltas = deltas[deltas > 0]
+    if len(deltas) >= 2:
+        expected = deltas.median()
+        if expected > 0:
+            spacings = (deltas / expected).round()
+            grid_gaps = int((spacings[spacings > 1] - 1).sum())
+
+    report = {
+        "prices_filled": prices_filled,
+        "volumes_filled": volumes_filled,
+        "leading_rows_dropped": leading_dropped,
+        "grid_gaps": grid_gaps,
+    }
+    return df, report
+
+
 # --- NEW: Function to process raw tick data ---
 def process_raw_tick_data(symbol: str) -> str | None:
     """
@@ -23,13 +72,12 @@ def process_raw_tick_data(symbol: str) -> str | None:
         # Read the raw tick data, setting the 'timestamp' column as the index.
         df = pd.read_csv(input_file, index_col='timestamp')
         
-        # Ensure data columns have the correct numeric type.
-        for col in ['price', 'volume']:
-            df[col] = pd.to_numeric(df[col], errors='coerce')
-        
-        df.dropna(inplace=True)
-        df.sort_index(inplace=True)
-        
+        # Repair missing values instead of silently dropping rows, and log
+        # what was repaired so data problems stay visible
+        df, report = forward_fill_ticks(df)
+        if any(report.values()):
+            logger.warning(f"Data quality for {symbol}: {report}")
+
         # --- CHANGE: Save to a new Parquet file for ticks ---
         output_file = Path(f"data/ticks_{symbol}.parquet")
         df.to_parquet(output_file)

--- a/src/data/CSVDataReader.cpp
+++ b/src/data/CSVDataReader.cpp
@@ -1,4 +1,5 @@
 #include "qse/data/CSVDataReader.h"
+#include "qse/core/Debug.h"
 #include <fstream>
 #include <sstream>
 #include <iostream>
@@ -6,6 +7,44 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+
+namespace {
+
+// Counts missing rows in a time grid: the expected spacing is the median of
+// consecutive deltas, and any delta rounding to k spacings contributes k-1
+// missing rows. Exact for grid data; a heuristic for event-time series.
+template <typename Series, typename GetTs>
+std::size_t count_grid_gaps(const Series& rows, GetTs get_ts) {
+    if (rows.size() < 3) {
+        return 0;
+    }
+    std::vector<long long> deltas;
+    deltas.reserve(rows.size() - 1);
+    for (std::size_t i = 1; i < rows.size(); ++i) {
+        long long d = get_ts(rows[i]) - get_ts(rows[i - 1]);
+        if (d > 0) {
+            deltas.push_back(d);
+        }
+    }
+    if (deltas.size() < 2) {
+        return 0;
+    }
+    std::vector<long long> sorted = deltas;
+    std::nth_element(sorted.begin(), sorted.begin() + sorted.size() / 2, sorted.end());
+    const long long expected = sorted[sorted.size() / 2];
+    if (expected <= 0) {
+        return 0;
+    }
+    std::size_t gaps = 0;
+    for (long long d : deltas) {
+        if (d > expected + expected / 2) {
+            gaps += static_cast<std::size_t>((d + expected / 2) / expected) - 1;
+        }
+    }
+    return gaps;
+}
+
+} // namespace
 
 namespace qse {
 
@@ -36,15 +75,24 @@ void CSVDataReader::load_data() {
     
     std::string line;
     if (isBar) {
-        std::cout << "Detected Bar data format in " << file_path_ << std::endl;
+        if (qse_debug_enabled()) std::cout << "Detected Bar data format in " << file_path_ << std::endl;
         while (std::getline(file, line)) {
+            if (line.empty()) {
+                continue; // trailing newlines are not data-quality problems
+            }
             std::stringstream ss(line);
             std::string item;
             std::vector<std::string> tokens;
             while(std::getline(ss, item, ',')) {
                 tokens.push_back(item);
             }
-            if(tokens.size() >= 6) {
+            if (tokens.size() < 6) {
+                ++skipped_rows_;
+                continue;
+            }
+            // A row with missing or non-numeric fields is counted and
+            // skipped; one bad row must not abort the whole load
+            try {
                 Bar bar;
                 bar.symbol = symbol_override_.empty() ? "UNKNOWN" : symbol_override_;
                 bar.timestamp = qse::Timestamp(std::chrono::seconds(std::stoll(tokens[0])));
@@ -54,59 +102,85 @@ void CSVDataReader::load_data() {
                 bar.close = std::stod(tokens[4]);
                 bar.volume = std::stoull(tokens[5]);
                 bars_.push_back(bar);
+            } catch (const std::exception&) {
+                ++skipped_rows_;
             }
         }
+
+        std::sort(bars_.begin(), bars_.end(),
+            [](const Bar& a, const Bar& b) { return a.timestamp < b.timestamp; });
+        gap_count_ = count_grid_gaps(bars_, [](const Bar& b) {
+            return static_cast<long long>(b.timestamp.time_since_epoch().count());
+        });
     } else {
-        std::cout << "Detected Tick data format in " << file_path_ << std::endl;
+        if (qse_debug_enabled()) std::cout << "Detected Tick data format in " << file_path_ << std::endl;
         while (std::getline(file, line)) {
+            if (line.empty()) {
+                continue;
+            }
             std::stringstream ss(line);
             std::string item;
             std::vector<std::string> tokens;
             while(std::getline(ss, item, ',')) {
                 tokens.push_back(item);
             }
-            if(tokens.size() >= 8) {
-                // Full tick format: timestamp,symbol,price,volume,bid,ask,bid_size,ask_size
-                Tick tick;
-                {
-                    long long raw = std::stoll(tokens[0]);
-                    if (raw < 10'000'000'000LL) {
-                        raw *= 1000; // CSV provides seconds – promote to ms
+            try {
+                if(tokens.size() >= 8) {
+                    // Full tick format: timestamp,symbol,price,volume,bid,ask,bid_size,ask_size
+                    Tick tick;
+                    {
+                        long long raw = std::stoll(tokens[0]);
+                        if (raw < 10'000'000'000LL) {
+                            raw *= 1000; // CSV provides seconds – promote to ms
+                        }
+                        tick.timestamp = qse::Timestamp(std::chrono::milliseconds(raw));
                     }
-                    tick.timestamp = qse::Timestamp(std::chrono::milliseconds(raw));
-                }
-                tick.symbol = symbol_override_.empty() ? tokens[1] : symbol_override_;
-                tick.price = std::stod(tokens[2]);
-                tick.volume = std::stoull(tokens[3]);
-                tick.bid = std::stod(tokens[4]);
-                tick.ask = std::stod(tokens[5]);
-                tick.bid_size = std::stoull(tokens[6]);
-                tick.ask_size = std::stoull(tokens[7]);
-                ticks_.push_back(tick);
-            } else if(tokens.size() >= 3) {
-                // Legacy format: timestamp,price,volume
-                Tick tick;
-                {
-                    long long raw = std::stoll(tokens[0]);
-                    if (raw < 10'000'000'000LL) {
-                        raw *= 1000;
+                    tick.symbol = symbol_override_.empty() ? tokens[1] : symbol_override_;
+                    tick.price = std::stod(tokens[2]);
+                    tick.volume = std::stoull(tokens[3]);
+                    tick.bid = std::stod(tokens[4]);
+                    tick.ask = std::stod(tokens[5]);
+                    tick.bid_size = std::stoull(tokens[6]);
+                    tick.ask_size = std::stoull(tokens[7]);
+                    ticks_.push_back(tick);
+                } else if(tokens.size() >= 3) {
+                    // Legacy format: timestamp,price,volume
+                    Tick tick;
+                    {
+                        long long raw = std::stoll(tokens[0]);
+                        if (raw < 10'000'000'000LL) {
+                            raw *= 1000;
+                        }
+                        tick.timestamp = qse::Timestamp(std::chrono::milliseconds(raw));
                     }
-                    tick.timestamp = qse::Timestamp(std::chrono::milliseconds(raw));
+                    tick.symbol = symbol_override_.empty() ? "UNKNOWN" : symbol_override_;
+                    tick.price = std::stod(tokens[1]);
+                    tick.volume = std::stoull(tokens[2]);
+                    tick.bid = tick.price; // Use price as bid/ask for legacy format
+                    tick.ask = tick.price;
+                    tick.bid_size = tick.volume; // Use volume as size for legacy format
+                    tick.ask_size = tick.volume;
+                    ticks_.push_back(tick);
+                } else {
+                    ++skipped_rows_;
                 }
-                tick.symbol = symbol_override_.empty() ? "UNKNOWN" : symbol_override_;
-                tick.price = std::stod(tokens[1]);
-                tick.volume = std::stoull(tokens[2]);
-                tick.bid = tick.price; // Use price as bid/ask for legacy format
-                tick.ask = tick.price;
-                tick.bid_size = tick.volume; // Use volume as size for legacy format
-                tick.ask_size = tick.volume;
-                ticks_.push_back(tick);
+            } catch (const std::exception&) {
+                ++skipped_rows_;
             }
         }
-        
+
         // Sort ticks by timestamp
-        std::sort(ticks_.begin(), ticks_.end(), 
+        std::sort(ticks_.begin(), ticks_.end(),
             [](const Tick& a, const Tick& b) { return a.timestamp < b.timestamp; });
+        gap_count_ = count_grid_gaps(ticks_, [](const Tick& t) {
+            return static_cast<long long>(t.timestamp.time_since_epoch().count());
+        });
+    }
+
+    if (skipped_rows_ > 0 || gap_count_ > 0) {
+        std::cerr << "[CSVDataReader] Data quality warning for " << file_path_
+                  << ": " << skipped_rows_ << " unparseable row(s) skipped, "
+                  << gap_count_ << " missing row(s) in the time grid" << std::endl;
     }
 }
 

--- a/tests/cpp/DataGapsTest.cpp
+++ b/tests/cpp/DataGapsTest.cpp
@@ -1,0 +1,93 @@
+// B1: the reader must tolerate malformed rows (count them, don't abort) and
+// surface missing rows in the time grid via gap_count().
+
+#include <gtest/gtest.h>
+#include "qse/data/CSVDataReader.h"
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+namespace {
+
+class DataGapsTest : public ::testing::Test {
+protected:
+    std::string path_;
+
+    void write_file(const std::string& name, const std::string& content) {
+        path_ = name;
+        std::ofstream file(path_);
+        file << content;
+    }
+
+    void TearDown() override {
+        if (!path_.empty()) {
+            std::remove(path_.c_str());
+        }
+    }
+};
+
+} // namespace
+
+TEST_F(DataGapsTest, CleanBarFileReportsZero) {
+    write_file("gaps_clean.csv",
+        "timestamp,open,high,low,close,volume\n"
+        "1000,10,11,9,10.5,100\n"
+        "1060,10.5,11,10,10.8,120\n"
+        "1120,10.8,11.2,10.5,11,90\n"
+        "1180,11,11.5,10.9,11.2,80\n");
+    qse::CSVDataReader reader(path_, "TEST");
+    EXPECT_EQ(reader.read_all_bars().size(), 4u);
+    EXPECT_EQ(reader.skipped_row_count(), 0u);
+    EXPECT_EQ(reader.gap_count(), 0u);
+}
+
+TEST_F(DataGapsTest, MalformedBarRowsAreSkippedAndCounted) {
+    // One row with an empty close field, one row with too few columns;
+    // neither may abort the load
+    write_file("gaps_malformed.csv",
+        "timestamp,open,high,low,close,volume\n"
+        "1000,10,11,9,10.5,100\n"
+        "1060,10.5,11,10,,120\n"
+        "1120,10.8\n"
+        "1180,11,11.5,10.9,11.2,80\n");
+    qse::CSVDataReader reader(path_, "TEST");
+    EXPECT_EQ(reader.read_all_bars().size(), 2u);
+    EXPECT_EQ(reader.skipped_row_count(), 2u);
+}
+
+TEST_F(DataGapsTest, MissingBarsInGridAreCounted) {
+    // 60s grid with bars at t, t+60, t+120, then a jump to t+360:
+    // t+180, t+240, t+300 are missing -> 3 gaps
+    write_file("gaps_grid.csv",
+        "timestamp,open,high,low,close,volume\n"
+        "1000,10,11,9,10.5,100\n"
+        "1060,10.5,11,10,10.8,120\n"
+        "1120,10.8,11.2,10.5,11,90\n"
+        "1360,11,11.5,10.9,11.2,80\n"
+        "1420,11.2,11.6,11,11.4,70\n");
+    qse::CSVDataReader reader(path_, "TEST");
+    EXPECT_EQ(reader.read_all_bars().size(), 5u);
+    EXPECT_EQ(reader.skipped_row_count(), 0u);
+    EXPECT_EQ(reader.gap_count(), 3u);
+}
+
+TEST_F(DataGapsTest, TickGridGapsAndBadRowsAreCounted) {
+    // Legacy tick format on a 60s grid: one unparseable price (1060) and one
+    // genuinely missing row (1360). The skipped row leaves a hole in the
+    // grid, so both register as gaps: deltas {120,60,60,60,120}, median 60,
+    // and each 120 delta contributes one missing row.
+    write_file("gaps_ticks.csv",
+        "timestamp,price,volume\n"
+        "1000,100.0,500\n"
+        "1060,not_a_price,500\n"
+        "1120,100.4,500\n"
+        "1180,100.5,500\n"
+        "1240,100.6,500\n"
+        "1300,100.8,500\n"
+        "1420,100.9,500\n");
+    qse::CSVDataReader reader(path_, "TEST");
+    EXPECT_EQ(reader.read_all_ticks().size(), 6u);
+    EXPECT_EQ(reader.skipped_row_count(), 1u);
+    EXPECT_EQ(reader.gap_count(), 2u);
+}

--- a/tests/python/test_process_data.py
+++ b/tests/python/test_process_data.py
@@ -1,0 +1,98 @@
+"""Unit tests for forward_fill_ticks in scripts/data/process_data.py (B1).
+
+Fixtures are synthetic gappy tick data; every filled value and every report
+count is asserted exactly.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "data"))
+
+from process_data import forward_fill_ticks  # noqa: E402
+
+
+def make_df(timestamps, prices, volumes):
+    return pd.DataFrame({"price": prices, "volume": volumes},
+                        index=pd.Index(timestamps, name="timestamp"))
+
+
+class TestForwardFill:
+    def test_missing_price_is_forward_filled(self):
+        df = make_df([1000, 1060, 1120, 1180],
+                     [100.0, np.nan, np.nan, 101.0],
+                     [500, 400, 300, 200])
+        clean, report = forward_fill_ticks(df)
+
+        assert clean.loc[1060, "price"] == pytest.approx(100.0)
+        assert clean.loc[1120, "price"] == pytest.approx(100.0)
+        assert clean.loc[1180, "price"] == pytest.approx(101.0)
+        assert report["prices_filled"] == 2
+        assert len(clean) == 4
+
+    def test_missing_volume_becomes_zero(self):
+        df = make_df([1000, 1060, 1120],
+                     [100.0, 100.5, 101.0],
+                     [500, np.nan, 300])
+        clean, report = forward_fill_ticks(df)
+
+        assert clean.loc[1060, "volume"] == 0
+        assert report["volumes_filled"] == 1
+        assert report["prices_filled"] == 0
+
+    def test_leading_rows_without_price_are_dropped(self):
+        df = make_df([1000, 1060, 1120, 1180],
+                     [np.nan, np.nan, 100.0, 100.5],
+                     [500, 400, 300, 200])
+        clean, report = forward_fill_ticks(df)
+
+        assert len(clean) == 2
+        assert clean.index.tolist() == [1120, 1180]
+        assert report["leading_rows_dropped"] == 2
+        assert report["prices_filled"] == 0
+
+    def test_non_numeric_values_are_coerced_and_filled(self):
+        df = make_df([1000, 1060, 1120],
+                     [100.0, "bad_value", 101.0],
+                     [500, "also_bad", 300])
+        clean, report = forward_fill_ticks(df)
+
+        assert clean.loc[1060, "price"] == pytest.approx(100.0)
+        assert clean.loc[1060, "volume"] == 0
+        assert report["prices_filled"] == 1
+        assert report["volumes_filled"] == 1
+
+    def test_grid_gaps_are_counted(self):
+        # 60s grid with 1180 and 1240 missing -> the 1120->1300 delta spans
+        # 3 spacings -> 2 missing rows
+        df = make_df([1000, 1060, 1120, 1300, 1360, 1420],
+                     [100.0, 100.1, 100.2, 100.3, 100.4, 100.5],
+                     [500, 500, 500, 500, 500, 500])
+        clean, report = forward_fill_ticks(df)
+
+        assert report["grid_gaps"] == 2
+        assert len(clean) == 6  # gaps are reported, not fabricated
+
+    def test_unsorted_input_is_sorted(self):
+        df = make_df([1120, 1000, 1060],
+                     [101.0, 100.0, np.nan],
+                     [300, 500, 400])
+        clean, _ = forward_fill_ticks(df)
+
+        assert clean.index.tolist() == [1000, 1060, 1120]
+        # After sorting, the 1060 NaN fills from 1000's price, not 1120's
+        assert clean.loc[1060, "price"] == pytest.approx(100.0)
+
+    def test_clean_data_reports_all_zero(self):
+        df = make_df([1000, 1060, 1120],
+                     [100.0, 100.5, 101.0],
+                     [500, 400, 300])
+        clean, report = forward_fill_ticks(df)
+
+        assert report == {"prices_filled": 0, "volumes_filled": 0,
+                          "leading_rows_dropped": 0, "grid_gaps": 0}
+        pd.testing.assert_frame_equal(clean, df, check_dtype=False)


### PR DESCRIPTION
## What

Implements B1 (missing-data handling) from docs/TASK_BREAKDOWN.md Track B - repairs and *reports* data problems on both sides of the pipeline instead of silently discarding or crashing.

**Python** (`scripts/data/process_data.py`):
- New pure function `forward_fill_ticks(df) -> (clean_df, report)` replaces the silent `dropna()`: prices forward-fill from the last valid observation, missing volumes become 0 ("no trade printed", not a trade of unknown size), rows before the first valid price are dropped explicitly
- Every repair is counted in the report (`prices_filled`, `volumes_filled`, `leading_rows_dropped`, `grid_gaps`) and logged as a warning when non-zero
- 7 pytest cases in `tests/python/test_process_data.py` assert exact filled values, including the sort-before-fill case (gaps must fill from the past, not the future)

**C++** (`CSVDataReader`):
- One malformed field (empty close, stray string) previously threw `std::invalid_argument` out of the constructor and killed the entire run - there was no exception handling at all. Rows now parse inside try/catch; bad rows are counted via `skipped_row_count()`
- Missing rows in the time grid are detected by median-spacing inference and surfaced via `gap_count()` (exact for grid data, heuristic for event-time ticks)
- A one-line data-quality warning prints to stderr when a file needed repairs; bars are now sorted on load (matching tick behavior)
- 4 gtest cases in `tests/cpp/DataGapsTest.cpp`: clean file, malformed rows, a 3-bar hole in a 60s grid, and a skipped bad row correctly registering as a grid gap

## Why

Phase 6 of the roadmap: institutional-grade inputs. Silent `dropna()` and crash-on-bad-row are the two classic ways backtests quietly consume corrupted data; both paths now repair what they can and report what they did.

## Reviewer notes

- `ParquetDataReader` deliberately left as-is (Arrow handles nulls upstream, and it is not the primary ingest path) - noted in the breakdown for revisit
- The gap heuristic uses the median of positive deltas as the expected spacing and counts `round(delta/expected) - 1` per oversized delta; it needs a majority-intact grid, which is documented
- 211/211 ctest (4 new), 23/23 pytest (7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
